### PR TITLE
disable python-mpi binary on Garnet

### DIFF
--- a/externalPackages/mpi4pyConfig/build.garnet.gnu
+++ b/externalPackages/mpi4pyConfig/build.garnet.gnu
@@ -1,1 +1,3 @@
+x=$(patch -Nup1 < ../mpi4pyConfig/no-python-mpi.patch.garnet)
+echo "$x"
 ${PROTEUS_PYTHON} setup.py build build_exe --mpicxx=CC --mpicc=cc --mpif77=ftn --mpif90=ftn --configure

--- a/externalPackages/mpi4pyConfig/no-python-mpi.patch.garnet
+++ b/externalPackages/mpi4pyConfig/no-python-mpi.patch.garnet
@@ -1,0 +1,10 @@
+--- mpi4py/setup.py	2013-10-17 09:06:01.000000000 -0500
++++ mpi4py-no-python-mpi/setup.py	2013-10-22 10:45:45.000000000 -0500
+@@ -467,7 +467,6 @@
+                                       'mpi_c.pxd',]},
+           ext_modules  = [Ext(**ext) for ext in ext_modules()],
+           libraries    = [Lib(**lib) for lib in libraries()  ],
+-          executables  = [Exe(**exe) for exe in executables()],
+           **metadata)
+ 
+ def chk_cython(VERSION):


### PR DESCRIPTION
Another patch, this time to disable the PythonMPI binary on Garnet, which doesn't seem to be building correctly in my environment.  
