### PR TITLE
[tracking] test 64-bit profile builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: install
 #grab environment variables from shell if they are not set
 
 PROTEUS ?= $(shell pwd)
-PROTEUS_ARCH ?= $(shell python -c "import sys; print sys.platform")
+PROTEUS_ARCH ?= linux2-64
 PROTEUS_PREFIX ?= ${PROTEUS}/${PROTEUS_ARCH}
 PROTEUS_PYTHON ?= ${PROTEUS_PREFIX}/bin/python
 


### PR DESCRIPTION
This is a tracking issue for testing a 64-bit version of Proteus on Linux.

We'll likely rebase/squash the majority of the work in this branch, so feel free to make partially-working commits into this while we hack on this.

You will need to go into your `stack` directory and merge in the pull requests from https://github.com/hashdist/hashstack2/pull/107 to get this working.  I suppose I could just add this to the Makefile, but I need to leave at least a little manual work in here :)
