### PR TITLE
added option to save solution DOF after the time step

### DIFF
--- a/scripts/parun
+++ b/scripts/parun
@@ -176,6 +176,12 @@ parser.add_option("-F","--generatePartitionedMeshFromFiles",
                   action="store_true",
                   help="""generate a parallel mesh directly from files (saves memory overhead of storing global mesh)""")
 
+parser.add_option("-S","--save_dof",
+                  default=False,
+                  dest="save_dof",
+                  action="store_true",
+                  help="""save the solution degrees of freedom after they have been calculated (for interactive plotting)""")
+
 (opts,args) = parser.parse_args()
 
 

--- a/src/NumericalSolution.py
+++ b/src/NumericalSolution.py
@@ -473,6 +473,11 @@ class  NS_base:#(HasTraits):
             if index in so.modelSpinUpList:
                 self.modelSpinUpList.append(model)
         log("Finished setting up models and solvers")
+        if self.opts.save_dof:
+            for m in self.modelList:
+                for lm in m.levelModelList:
+                    for ci in range(lm.coefficients.nc):
+                        lm.u[ci].dof_last = lm.u[ci].dof.copy()
         self.archiveFlag= so.archiveFlag
         log("Setting up SimTools for "+p.name)
         self.simOutputList = []
@@ -610,6 +615,9 @@ class  NS_base:#(HasTraits):
             for lm,lu,lr in zip(m.levelModelList,
                                 m.uList,
                                 m.rList):
+                if self.opts.save_dof:
+                    for ci in range(lm.coefficients.nc):
+                        lm.u[ci].dof_last[:] = lm.u[ci].dof
                 #calculate the coefficients, any explicit terms will be wrong
                 lm.timeTerm=False
                 lm.getResidual(lu,lr)
@@ -665,6 +673,11 @@ class  NS_base:#(HasTraits):
             log("==============================================================",level=0)
             log("Solving over interval [%12.5e,%12.5e]" % (self.tn_last,self.tn),level=0)
             log("==============================================================",level=0)
+            if self.opts.save_dof:
+                for m in self.modelList:
+                    for lm in m.levelModelList:
+                        for ci in range(lm.coefficients.nc):
+                            lm.u[ci].dof_last[:] = lm.u[ci].dof
             #
             if self.systemStepController.stepExact and self.systemStepController.t_system_last != self.tn:
                 self.systemStepController.stepExact_system(self.tn)

--- a/src/TriangleTools.py
+++ b/src/TriangleTools.py
@@ -603,7 +603,6 @@ number of edges         = %d
         if not nodesA == None:
             triangleWrappers.setPointAttributes(tri0,nodesA)
         #end if
-        print "segmenat Markers ===================",segmentsM
         if segmentsM == None:
             triangleWrappers.setSegments(tri0,segments)
         else:

--- a/src/iproteus.py
+++ b/src/iproteus.py
@@ -164,6 +164,12 @@ parser.add_option("-F","--generatePartitionedMeshFromFiles",
                   action="store_true",
                   help="""generate a parallel mesh directly from files (saves memory overhead of storing global mesh)""")
 
+parser.add_option("-S","--save_dof",
+                  default=False,
+                  dest="save_dof",
+                  action="store_true",
+                  help="""save the solution degrees of freedom after they have been calculated (for interactive plotting)""")
+
 
 (opts,args) = parser.parse_args(args=[])
 


### PR DESCRIPTION
When we run interactively using a compute thread, the monitoring thread needs to grab an array that has a valid solution in it, otherwise you can get unconverged solution DOF. This adds the option --save_dof  that causes a copy of the dof to be stored when they are valid solutions.
