### PR TITLE
updated to new hit syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ profile: ${PROTEUS_PREFIX}/artifact.json
 
 ${PROTEUS_PREFIX}/artifact.json: stack hashdist ${BOOTSTRAP}
 	cp stack/examples/proteus.${PROTEUS_ARCH}.yaml stack/default.yaml
-	cd stack && ${PROTEUS}/hashdist/bin/hit develop -k error -f ${PROTEUS_PREFIX}
+	cd stack && ${PROTEUS}/hashdist/bin/hit default.yaml develop -k error -f ${PROTEUS_PREFIX}
 	-cp ${PROTEUS}/${PROTEUS_ARCH}/bin/python2.7.exe.link ${PROTEUS}/${PROTEUS_ARCH}/bin/python2.7.link
 
 config.py:


### PR DESCRIPTION
As of https://github.com/hashdist/hashdist/commit/610985 we now have to
specify the profile file being used if we're going to use the `target`
positional argument.
