### PR TITLE
Resolve real path of PROTEUS dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: install
 
 SHELL=/usr/bin/env bash
 
-PROTEUS ?= $(shell pwd)
+PROTEUS ?= $(shell python -c "import os; print os.path.realpath(os.getcwd())")
 VER_CMD = git log -1 --pretty="%H"
 # shell hack for now to automatically detect Garnet front-end nodes
 PROTEUS_ARCH ?= $(shell [[ $$(hostname) = garnet* ]] && echo "garnet.gnu" || python -c "import sys; print sys.platform")


### PR DESCRIPTION
This is helpful on HPC systems where the current working dir may
not be the absolute path, leading to hashdist launcher errors
