### PR TITLE
Add time stamp traces to log events

### DIFF
--- a/src/Profiling.py
+++ b/src/Profiling.py
@@ -2,8 +2,13 @@
 Tools for high level profiling and event logging
 """
 import gc
-import os
 import inspect
+from time import time
+
+try:
+    from cProfile import Profile
+except:
+    from profile import Profile
 
 global memHardLimit,memLast,memLog,logFile,logLevel,verbose,procID,logAllProcesses,flushBuffer, preInitBuffer
 
@@ -20,6 +25,9 @@ procID=None
 flushBuffer=False
 preInitBuffer=[]
 logDir = '.'
+
+startTime = time()
+
 def memProfOn():
     global memLog
     memLog = True
@@ -63,7 +71,7 @@ def closeLog():
     except:
         pass
 
-def logEvent(stringIn,level=1,data=None):
+def logEvent(stringIn, level=1, data=None):
     global logLevel,procID,logAllProcesses,flushBuffer,preInitBuffer
     if procID != None:
         if logAllProcesses or procID==0:
@@ -74,9 +82,10 @@ def logEvent(stringIn,level=1,data=None):
                 else:
                     string = stringIn
                 if string!=None:
-                    if data != None:
-                        string += `data`
-                    string+='\n'
+                    if data:
+                        string += repr(data)
+                    string +='\n'
+                    string = ("[%8d] " % (time() - startTime)) + string
                     global logFile,verbose
                     logFile.write(string)
                     if flushBuffer:


### PR DESCRIPTION
Here's some sample log output:

```
[       1] Initializing OneLevelTransport
[       1] Sparse diffusion information key (0, 0) = (array([0, 3, 6, 9], dtype=int32), array([0, 1, 2, 0, 1, 2, 0, 1, 2], dtype=int32))
[       1] Shallow copy of trial shape is being used for test shape w
[       1] Shallow copy of trial shape is being used for test shape grad(w)
[       1] Shallow copy of trial shape is being used for test shape w
[       1] Updating local to global mappings
[       1] Building time integration object
[       1] Calculating numerical quadrature formulas
[       1] Element Quadrature
[       4] Element Boundary Quadrature
[       4] Global Exterior Element Boundary Quadrature
[       5] Allocating residual and solution vectors
[       5] Allocating Jacobian
[       5] Building sparse matrix structure
[       5] Allocating parallel storage
[       5] Allocating ghosted parallel vectors on rank 0
[       5] Allocating un-ghosted parallel vectors on rank 0
[       5] Allocating matrix on rank 0
[       5] ParMat_petsc4py comm.rank= 0 blockSize = 1 par_n= 2513 par_N=2513 par_nghost=0 par_jacobian.getSizes()= ((2513, 2513), (2513, 2513))
[       5] Building Mesh Transfers
[       5] Setting poisson_3d_tetgen_c0p1pe1 stepController to proteus.StepControl.SC_base
[       5] Setting up MultilevelLinearSolver forpoisson_3d_tetgen_c0p1pe1
[       5] multilevelLinearSolverChooser type= proteus.LinearSolvers.KSP_petsc4py
```

I like this format since it's easy to see how long the simulation has run and do to mental math for how long time steps are taking.  We could switch to a "date-time" format if that's preferred (I don't have a strong preference).
