### PR TITLE
run triangle only on master process and support genMesh=False for PSLG domains

### DIFF
--- a/src/NumericalSolution.py
+++ b/src/NumericalSolution.py
@@ -220,9 +220,15 @@ class  NS_base:#(HasTraits):
                 tmesh = TriangleTools.TriangleBaseMesh(baseFlags=n.triangleOptions,
                                                        nbase=1,
                                                        verbose=10)
-                tmesh.readFromPolyFile(p.domain.polyfile)
-                log("Converting to Proteus Mesh")
-                mesh=tmesh.convertToProteusMesh(verbose=1)
+                if comm.isMaster() and p.genMesh:
+                    tmesh.readFromPolyFile(p.domain.polyfile)
+                    tmesh.writeToFile(p.domain.polyfile)
+                    log("Converting to Proteus Mesh")
+                    mesh=tmesh.convertToProteusMesh(verbose=1)
+                comm.barrier()
+                if not comm.isMaster() or not p.genMesh:
+                    mesh = MeshTools.TriangularMesh()
+                    mesh.generateFromTriangleFiles(filebase=p.domain.polyfile,base=1)
                 mlMesh = MeshTools.MultilevelTriangularMesh(0,0,0,skipInit=True,
                                                             nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                             parallelPartitioningType=n.parallelPartitioningType)


### PR DESCRIPTION
This should work in serial and parallel, with genMesh=True or False. It changes the parallel behavior to only run triangle on comm.isMaster and generate triangle mesh files form that, then read them on all other processes. If genMesh=False it reads them on all processes so they must have been generated  in prior step.
