### PR TITLE
PEP8 Refactor NonlinearSolvers.py

### DIFF
--- a/src/NonlinearSolvers.py
+++ b/src/NonlinearSolvers.py
@@ -538,7 +538,6 @@ class Newton(NonlinearSolver):
                 print "lambda_i_min",min(self.linearSolver.eigenvalues_i)
             if self.lineSearch:
                 norm_r_cur = self.norm(r)
-                norm_r_last = 2.0*norm_r_cur
                 ls_its = 0
                     #print norm_r_cur,self.atol_r,self.rtol_r
     #                 while ( (norm_r_cur >= 0.99 * self.norm_r + self.atol_r) and


### PR DESCRIPTION
Note: I left variable casing unchanged, since this is used consistently
elsewhere in Proteus.

Most of these changes do not affect functionality, however:
- I've changed at least one printed warning to an Exception
- I've removed dead code, and fixed a few broken imports/unresolved
  references
- I moved the csmoothers import to the top-level of the module.  Module
  imports do not belong in objects, since they are Singletons with
  global state, and likely to confuse developers.

This is a no-change refactor.  It should be reviewed by at least one of @cekees and @mfarthin, preferably both, before merge.
