### PR TITLE
added elementBoundaryMaterialTypes for regular grids

### DIFF
--- a/src/Domain.py
+++ b/src/Domain.py
@@ -38,26 +38,29 @@ class RectangularDomain(D_base):
                  name="DefaultRectangularDomain",
                  units="m"):
         D_base.__init__(self,len(L),name,units)
+        self.boundaryTags = {'left':3,
+                             'right':5,
+                             'front':2,
+                             'back':6,
+                             'top':4,
+                             'bottom':1}
+        if self.nd==2:
+            self.boundaryTags = {'left':4,
+                                 'right':2,
+                                 'top':3,
+                                 'bottom':1}
+
         self.x=x
         self.L=L
     def writePoly(self,fileprefix):
         """
         Write the RectangularDomain using the poly format.
         """
-        self.boundaryLegend = {'left':3,
-                               'right':5,
-                               'front':2,
-                               'back':6,
-                               'top':4,
-                               'bottom':1}
+        self.boundaryLegend = self.boundaryTags
         unitesize=4.0/self.L[0]
         f = open(fileprefix+".poly",'w')
         if self.nd==2:
-            self.boundaryLegend = {'left':4,
-                                   'right':2,
-                                   'top':3,
-                                   'bottom':1}
-
+            self.boundaryLegend = self.boundaryTags
             fileString="""
 # vertices
 4 2 0 1

--- a/src/cmeshToolsModule.cpp
+++ b/src/cmeshToolsModule.cpp
@@ -805,6 +805,7 @@ static PyObject* cmeshToolsGenerateTriangularMeshFromRectangularGrid(PyObject* s
   regularRectangularToTriangularMeshElements(nx,ny,MESH(cmesh),triangleFlag);
   regularRectangularToTriangularMeshNodes(nx,ny,Lx,Ly,MESH(cmesh));
   constructElementBoundaryElementsArray_triangle(MESH(cmesh));
+  regularRectangularToTriangularElementBoundaryMaterials(Lx,Ly,MESH(cmesh));
   Py_INCREF(Py_None); 
   return Py_None;
 }
@@ -831,6 +832,7 @@ static PyObject* cmeshToolsGenerateHexahedralMeshFromRectangularGrid(PyObject* s
   regularHexahedralMeshElements(nx,ny,nz,px,py,pz,MESH(cmesh));
   regularMeshNodes(nx,ny,nz,Lx,Ly,Lz,MESH(cmesh));
   constructElementBoundaryElementsArray_hexahedron(MESH(cmesh));
+  regularHexahedralToTetrahedralElementBoundaryMaterials(Lx,Ly,Lz,MESH(cmesh));
   Py_INCREF(Py_None); 
   return Py_None;
 }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -138,6 +138,33 @@ extern "C"
     return 0;
   }
   
+  int regularRectangularToTriangularElementBoundaryMaterials(const double& Lx, const double& Ly, Mesh& mesh)
+  {
+    for (int ebNE = 0; ebNE < mesh.nExteriorElementBoundaries_global; ebNE++)
+      {
+	int ebN,nN_0,nN_1;
+	double x_0,y_0,x_1,y_1,epsilon=1.0e-8;
+	ebN = mesh.exteriorElementBoundariesArray[ebNE];
+	nN_0 = mesh.elementBoundaryNodesArray[ebN*2 + 0];
+	nN_1 = mesh.elementBoundaryNodesArray[ebN*2 + 1];
+	x_0 = mesh.nodeArray[nN_0*3+0];
+	y_0 = mesh.nodeArray[nN_0*3+1];
+	x_1 = mesh.nodeArray[nN_1*3+0];
+	y_1 = mesh.nodeArray[nN_1*3+1];
+	if (y_0 <= epsilon && y_1 <= epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 1;
+	else if (y_0 >= Ly - epsilon && y_1 >= Ly -  epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 3;
+	else if (x_0 <= epsilon && x_1 <= epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 4;
+	else if (x_0 >= Lx - epsilon && x_1 >= Lx - epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 2;
+	else
+	  assert(false);
+      }
+    return 0;
+  }
+
   int regularRectangularToTriangularMeshNodes(const int& nx, const int& ny, const double& Lx, const double& Ly, Mesh& mesh)
   {
     const double hx=Lx/(nx-1.0),hy=Ly/(ny-1.0);
@@ -155,6 +182,16 @@ extern "C"
           nN = i*nx+j;
           mesh.nodeArray[3*nN+0]=j*hx;
           mesh.nodeArray[3*nN+1]=i*hy;
+	  if (i==0)
+	    mesh.nodeMaterialTypes[nN] = 1;
+	  else if(i==ny-1)
+	    mesh.nodeMaterialTypes[nN] = 3;
+	  else if (j==0)
+	    mesh.nodeMaterialTypes[nN] = 4;
+	  else if(j==nx-1)
+	    mesh.nodeMaterialTypes[nN] = 2;
+	  else
+	    mesh.nodeMaterialTypes[nN] = 0;
         }
     return 0;
   }
@@ -194,6 +231,50 @@ extern "C"
     return 0;
   }
   
+  int regularHexahedralToTetrahedralElementBoundaryMaterials(const double& Lx, const double& Ly, const double& Lz, Mesh& mesh)
+  {
+    for (int ebNE = 0; ebNE < mesh.nExteriorElementBoundaries_global; ebNE++)
+      {
+	int ebN,nN_0,nN_1,nN_2;
+	double x_0,y_0,z_0,
+	  x_1,y_1,z_1,
+	  x_2,y_2,z_2,
+	  epsilon=1.0e-8;
+	ebN = mesh.exteriorElementBoundariesArray[ebNE];
+	nN_0 = mesh.elementBoundaryNodesArray[ebN*3 + 0];
+	nN_1 = mesh.elementBoundaryNodesArray[ebN*3 + 1];
+	nN_2 = mesh.elementBoundaryNodesArray[ebN*3 + 2];
+
+	x_0 = mesh.nodeArray[nN_0*3+0];
+	y_0 = mesh.nodeArray[nN_0*3+1];
+	z_0 = mesh.nodeArray[nN_0*3+2];
+
+	x_1 = mesh.nodeArray[nN_1*3+0];
+	y_1 = mesh.nodeArray[nN_1*3+1];	
+	z_1 = mesh.nodeArray[nN_1*3+2];
+
+	x_2 = mesh.nodeArray[nN_2*3+0];
+	y_2 = mesh.nodeArray[nN_2*3+1];	
+	z_2 = mesh.nodeArray[nN_2*3+2];
+
+	if (z_0 <= epsilon && z_1 <= epsilon && z_2 <= epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 1;
+	else if (z_0 >= Lz - epsilon && z_1 >= Lz -  epsilon && z_2 >= Lz -  epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 4;
+	else if (y_0 <= epsilon && y_1 <= epsilon && y_2 <= epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 2;
+	else if (y_0 >= Ly - epsilon && y_1 >= Ly -  epsilon && y_2 >= Ly -  epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 6;
+	else if (x_0 <= epsilon && x_1 <= epsilon && x_2 <= epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 3;
+	else if (x_0 >= Lx - epsilon && x_1 >= Lx - epsilon && x_2 >= Lx - epsilon)
+	  mesh.elementBoundaryMaterialTypes[ebN] = 5;
+	else
+	  assert(false);
+      }
+    return 0;
+  }
+
   int regularMeshNodes(const int& nx, 
                        const int& ny, 
                        const int& nz,
@@ -223,6 +304,20 @@ extern "C"
 	    mesh.nodeArray[3*nN+0]=k*hx;
 	    mesh.nodeArray[3*nN+1]=j*hy;
 	    mesh.nodeArray[3*nN+2]=i*hz;
+	    if (i==0)
+	      mesh.nodeMaterialTypes[nN] = 1;
+	    else if(i==nz-1)
+	      mesh.nodeMaterialTypes[nN] = 4;
+	    else if (j==0)
+	      mesh.nodeMaterialTypes[nN] = 2;
+	    else if(j==ny-1)
+	      mesh.nodeMaterialTypes[nN] = 6;
+	    else if (k==0)
+	      mesh.nodeMaterialTypes[nN] = 3;
+	    else if(k==nx-1)
+	      mesh.nodeMaterialTypes[nN] = 5;
+	    else
+	      mesh.nodeMaterialTypes[nN] = 0;
 	  }
     return 0;
   }

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -274,12 +274,14 @@ extern "C"
 
   int regularRectangularToTriangularMeshElements(const int& nx,const int& ny,Mesh& mesh, int triangleFlag);
   int regularRectangularToTriangularMeshNodes(const int& nx, const int& ny, const double& Lx, const double& Ly, Mesh& mesh);
+  int regularRectangularToTriangularElementBoundaryMaterials(const double& Lx, const double& Ly, Mesh& mesh);
   int globallyRefineTriangularMesh(const int& nLevels, Mesh& mesh, MultilevelMesh& multilevelMesh, bool averageNewNodeFlags=false);
 
 
   int regularMeshNodes(const int& nx,const int& ny,const int& nz, const double& Lx, const double& Ly, const double& Lz, Mesh& mesh);
   int regularHexahedralToTetrahedralMeshNodes(const int& nx,const int& ny,const int& nz, const double& Lx, const double& Ly, const double& Lz, Mesh& mesh);
   int regularHexahedralToTetrahedralMeshElements(const int& nx,const int& ny,const int& nz,Mesh& mesh);
+  int regularHexahedralToTetrahedralElementBoundaryMaterials(const double& Lx, const double& Ly, const double& Lz, Mesh& mesh);
   int regularHexahedralMeshElements(const int& nx,const int& ny,const int& nz,const int& px,const int& py,const int& pz, Mesh& mesh);
   int regularNURBSMeshElements(const int& nx,const int& ny,const int& nz,const int& px,const int& py,const int& pz,Mesh& mesh);
   


### PR DESCRIPTION
Wanted to make it easier to switch to a regular grid with boundary conditions set based  on tags (left, right, top, bottom, etc.). I added boundaryTags dicts to Domain.RectangularDomain and added functions to mesh.cpp to set elementBoundaryMaterialTypes and nodeMaterialTypes based on the  conventions in those  boundaryTags.
