### PR TITLE
changed log implementation

### DIFF
--- a/src/Profiling.py
+++ b/src/Profiling.py
@@ -55,14 +55,19 @@ def openLog(filename,level,logLocation=None):
     global logLevel
     global preInitBuffer
     global logDir
+    global procID
+    global logAllProcesses
     filename_full = filename
     import os
     if logLocation != None:
         logDir = logLocation
         filename_full = os.path.join(logDir,filename)
-    logFile=open(filename_full,'w')
+    if  procID == None or procID == 0:
+        logFile=open(filename_full,'w')
+    elif logAllProcesses:
+        logFile=open(filename_full+`procID`,'w')
     logLevel = level
-    for (string,level,data) in preInitBuffer:
+    for string,level,data in preInitBuffer:
         logEvent(string,level,data)
 
 def closeLog():
@@ -83,7 +88,7 @@ def logEvent(stringIn, level=1, data=None):
                 else:
                     string = stringIn
                 if string!=None:
-                    if data:
+                    if data!=None:
                         string += repr(data)
                     string +='\n'
                     string = ("[%8d] " % (time() - startTime)) + string


### PR DESCRIPTION
Open one log on master (default) or one unique log  per mpi task (if logAllProcesses  is True).  We had been letting all  mpi processes open the same file, which is pointless when only the master processes is  writing anyway and probably not smart  when we're logging all processes. This changes fixes the problem on garnet where the first  part of the  log file was binary. 
