### PR TITLE
system python3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: install
 
 SHELL=/usr/bin/env bash
 
-PROTEUS ?= $(shell python -c "import os; print os.path.realpath(os.getcwd())")
+PROTEUS ?= $(shell python -c "from __future__ import print_function; import os; print(os.path.realpath(os.getcwd()))")
 VER_CMD = git log -1 --pretty="%H"
 PROTEUS_INSTALL_CMD = python setup.py install
 PROTEUS_DEVELOP_CMD = pip install -e .


### PR DESCRIPTION
Should be safe to use either Python3 or Python2 to get system info now in Makefile.
