### PR TITLE
Add user warnings for parun -F

### DIFF
--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -332,6 +332,8 @@ class NS_base:  # (HasTraits):
                                                              parallelPartitioningType=n.parallelPartitioningType)
                 if opts.generatePartitionedMeshFromFiles:
                     logEvent("Generating partitioned mesh from Tetgen files")
+                    if("f" not in n.triangleOptions or "ee" not in n.triangleOptions):
+                        sys.exit("ERROR: Remake the mesh with the `f` flag and `ee` flags in triangleOptions.")
                     mlMesh.generatePartitionedMeshFromTetgenFiles(fileprefix,nbase,mesh,n.nLevels,
                                                                   nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                                   parallelPartitioningType=n.parallelPartitioningType)

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -319,9 +319,9 @@ class NS_base:  # (HasTraits):
                         logEvent("Warning: couldn't move {0:s}.1.neigh".format(fileprefix))
                         pass
                     try:
-                        logEvent("Warning: couldn't move {0:s}.1.edge".format(fileprefix))
                         check_call("mv {0:s}.1.edge {0:s}.edge".format(fileprefix), shell=True)
                     except:
+                        logEvent("Warning: couldn't move {0:s}.1.edge".format(fileprefix))
                         pass
                 comm.barrier()
                 logEvent("Initializing mesh and MultilevelMesh")

--- a/proteus/flcbdfWrappersModule.cpp
+++ b/proteus/flcbdfWrappersModule.cpp
@@ -3803,6 +3803,11 @@ int partitionNodesFromTetgenFiles(const char* filebase, int indexBase, Mesh& new
   //
   //8. Build subdomain meshes in new numbering, assumes memory not allocated in subdomain mesh
   //   
+  if(rank==0){
+    std::cerr<<"USER WARNING: In order to avoid a segmentation fault, you need to have supplied the 'f' flag to the triangleOptions input."<<std::endl;
+    std::cerr<<"USER WARNING: In order to avoid an edge assertion error, you need to have supplied the 'ee' flag to the triangleOptions input."<<std::endl; 
+  }
+
   if (newMesh.subdomainp == NULL)
     newMesh.subdomainp = new Mesh();
   newMesh.subdomainp->nElements_global = nElements_subdomain_new[rank] + elements_overlap.size();
@@ -3868,6 +3873,7 @@ int partitionNodesFromTetgenFiles(const char* filebase, int indexBase, Mesh& new
   ISDestroy(&nodeNumberingIS_global_old2new);
   //done with vertex file (and all file reads at this point)
   ierr = enforceMemoryLimit(rank, max_rss_gb,"Done reading vertices");CHKERRABORT(PROTEUS_COMM_WORLD, ierr);
+
   newMesh.subdomainp->elementNodesArray = new int[newMesh.subdomainp->nElements_global*newMesh.subdomainp->nNodes_element];
   newMesh.subdomainp->elementMaterialTypes = new int[newMesh.subdomainp->nElements_global];
   //


### PR DESCRIPTION
Aims to avoid issues #541 and #638 by supplying users with an assertion and several warning messages if `triangleOptions` does not have the appropriate flags, which is usually only an issue when dealing with large parallel runs. 

Also resolves a slight error that was made with a warning for moving the `.edge` file when a mesh is generated. 