### PR TITLE
Add hotstart time

### DIFF
--- a/proteus/Archiver.py
+++ b/proteus/Archiver.py
@@ -416,11 +416,11 @@ class AR_base:
             dataset = self.hdfFile.create_dataset(name  = name,
                                                   shape = tuple([offsets[-1]]+list(data.shape[1:])),
                                                   dtype = data.dtype)
-        except Exception as e:
-            print(e)
-            import pdb
-            pdb.set_trace()
-            dataset = self.hdfFile[name]
+        except:
+            try:
+                dataset = self.hdfFile[name]
+            except Exception as e:
+                raise e
         dataset[offsets[self.comm.rank()]:offsets[self.comm.rank()+1]] = data
 
 XdmfArchive=AR_base

--- a/proteus/Archiver.py
+++ b/proteus/Archiver.py
@@ -356,9 +356,12 @@ class AR_base:
                     dataset_name = TemporalGridCollection.attrib['Name']+"_"+ \
                                    `self.n_datasets`
                     dataset_name = dataset_name.replace(" ","_")
-                    xml_data  = self.hdfFile.create_dataset(name  = dataset_name,
-                                                            shape = (1,),
-                                                            dtype = '|S'+`max_grid_string_len`)
+                    try:
+                        xml_data  = self.hdfFile.create_dataset(name  = dataset_name,
+                                                                shape = (1,),
+                                                                dtype = '|S'+`max_grid_string_len`)
+                    except:
+                        xml_data = self.hdfFile[dataset_name]
                     if self.comm.isMaster():
                         xml_data[0] = tostring(GridLocal)
         self.n_datasets += 1
@@ -409,9 +412,15 @@ class AR_base:
             if i == self.comm.rank():
                 dataset[:] = data
     def create_dataset_sync(self,name,offsets,data):
-        dataset = self.hdfFile.create_dataset(name  = name,
-                                              shape = tuple([offsets[-1]]+list(data.shape[1:])),
-                                              dtype = data.dtype)
+        try:
+            dataset = self.hdfFile.create_dataset(name  = name,
+                                                  shape = tuple([offsets[-1]]+list(data.shape[1:])),
+                                                  dtype = data.dtype)
+        except Exception as e:
+            print(e)
+            import pdb
+            pdb.set_trace()
+            dataset = self.hdfFile[name]
         dataset[offsets[self.comm.rank()]:offsets[self.comm.rank()+1]] = data
 
 XdmfArchive=AR_base

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -1148,14 +1148,21 @@ class NS_base:  # (HasTraits):
             if self.opts.hotStart:
                 logEvent("Setting initial conditions from hot start file for "+p.name)
                 tCount = int(self.ar[index].tree.getroot()[-1][-1][-1][0].attrib['Name'])
+                offset=0
+                while tCount > 0:
+                    time = float(self.ar[index].tree.getroot()[-1][-1][-1-offset][0].attrib['Value'])
+                    if time < self.opts.hotStartTime:
+                        break
+                    else:
+                        tCount -=1
+                        offset +=1
                 self.ar[index].n_datasets = tCount + 1
-                time = float(self.ar[index].tree.getroot()[-1][-1][-1][0].attrib['Value'])
-                if len(self.ar[index].tree.getroot()[-1][-1]) > 1:
-                    dt = time - float(self.ar[index].tree.getroot()[-1][-1][-2][0].attrib['Value'])
+                if len(self.ar[index].tree.getroot()[-1][-1]) - offset - 1 > 0:
+                    dt = time - float(self.ar[index].tree.getroot()[-1][-1][-1-offset-1][0].attrib['Value'])
                 else:
-                    logEvent("Only one step in hot start file, setting dt to 1.0")
+                    logEvent("Not enough steps in hot start file set set dt, setting dt to 1.0")
                     dt = 1.0
-                logEvent("Last time step in hot start file was t = "+`time`)
+                logEvent("Hot starting from time step t = "+`time`)
                 for lm,lu,lr in zip(m.levelModelList,m.uList,m.rList):
                     for cj in range(lm.coefficients.nc):
                         lm.u[cj].femSpace.readFunctionXdmf(self.ar[index],lm.u[cj],tCount)

--- a/scripts/parun
+++ b/scripts/parun
@@ -161,11 +161,15 @@ parser.add_option("-n","--no_global_sync",
                   action="store_false",
                   help="""don't use a single hdf5 archive""")
 parser.add_option("-H","--hotStart",
-                  default=False,
                   dest="hotStart",
                   action="store_true",
-                  help="""Use the last step in the archive as the initial condition and continue appending to the
-                  archive""")
+                  help="""Use the last step in the archive as the initial condition and continue appending to the archive""")
+parser.add_option("-t","--hotStartTime",
+                  dest="hotStartTime",
+                  action="store",
+                  type="float",
+                  default=float('inf'),
+                  help="""Use the last step in the archive before t as the initial condition and continue appending to the archive""")
 parser.add_option("-B","--writeVelocityPostProcessor",
                   default=False,
                   dest="writeVPP",


### PR DESCRIPTION
Adds new `parun` option `-t`, which modifies the `-H` hotstart option to start from the first time step before the time provided to `-t`. For example:

```$ mpiexec -np 4 parun dambreak_so.py -O petsc.options.superlu_dist -C "T=0.5"```
```$ mpiexec -np 4 parun dambreak_so.py -O petsc.options.superlu_dist -C "T=1.0" -H -t 0.4```

Addresses #146 and #134 