### PR TITLE
Adds DofOrderInfo class for managing DOF ordering.

### DIFF
--- a/proteus/FemTools.py
+++ b/proteus/FemTools.py
@@ -5976,35 +5976,59 @@ from LinearAlgebraTools import ParVec
 import Comm
 
 class FiniteElementFunction:
-    """  A member of a finite element space of scalar functions.
+    """A member of a finite element space of scalar functions.
+
+    This class manages the calculation of function, gradient, tensor,
+    and trace values associated with a finite element function.
+    Typically, this function will be a scalar function  (For example,
+    in a 2D stokes problem with a pressure, and two velocity
+    components (say u or v), this class will manage the calculation of
+    one of the scalar functions for p, u or v.
 
     Arguments
     ---------
     finiteElementSpace : :class:`proteus.FemTools.ParametricFiniteElementSpace`
+
+    Notes
+    -----
+    `femSpace` and `dof` are the two main attributes of this class.
+    The `dof` attributes provide the scalar multiples for the
+    underlying basis functions that comes from `femSpace`'s
+    ParametricFiniteElementSpace object
     """
     def __init__(self,finiteElementSpace,dof=None,dim_dof=1,name="no_name",isVector=False):
+        #: Name assigned to the FiniteElementFunction instance
         self.name=name
+        #: boolean variable identifying whether the
+        #: finiteElementFunction is vector quantitied.
         self.isVector=isVector
+        #: :class:`proteus.FemTools.ParametricFiniteElementSpace`
+        #: provides information on the underlying finite element
+        #: space.
         self.femSpace = finiteElementSpace
+        #: integer variable with the global number of degrees of
+        #: freedom
         self.nDOF_global = self.femSpace.dim
+        #: dimension of the degree of freedom
         self.dim_dof = dim_dof
         self.range_dim_dof = range(self.dim_dof)
         if dof is not None:
+            #: numpy array of degree-of-freedom values used to
+            #: calculate the finite element function.
             self.dof=dof
         else:
             self.dof = numpy.zeros((self.femSpace.dim*dim_dof),
                                      'd')
+        #: boolean variable indentifying whether calculations should
+        #: use C-routines.
         self.useC=True
         #we need to be able to get references to existing values for values at nodes for some calculations
         #like vtkVisualization
         self.meshNodeValues = None
-        #add parallel capability to FiniteElementFunction now as well
+        #: for parallel FiniteElementFunciton capability
         self.par_dof = None
 
     def projectFromInterpolationConditions(self,interpolationValues):
-        #mwf debug
-#        import pdb
-#        pdb.set_trace()
         if self.useC and self.femSpace.referenceFiniteElement.interpolationConditions.projectFiniteElementFunctionFromInterpolationConditions_opt is not None:
             self.femSpace.referenceFiniteElement.interpolationConditions.projectFiniteElementFunctionFromInterpolationConditions_opt(self,interpolationValues)
         else:
@@ -6022,6 +6046,11 @@ class FiniteElementFunction:
             Global element number.
         xi : point
             Evaluation coordinate.
+
+        Returns
+        -------
+        value: float
+           The finite element functions value at xi.
         """
         value = 0.0
         for i,psi in zip(

--- a/proteus/LinearAlgebraTools.py
+++ b/proteus/LinearAlgebraTools.py
@@ -848,10 +848,10 @@ class LSCInv_shell(InvOperatorShell):
         self.B = B
         self.Bt = Bt
         self.F = F
-    
+
         self._constructBQinvBt()
         self._options = p4pyPETSc.Options()
-        
+
         if self._options.hasName('innerLSCsolver_BTinvBt_ksp_constant_null_space'):
             self._create_constant_nullspace()
             self.BQinvBt.setNullSpace(self.const_null_space)
@@ -912,14 +912,15 @@ class LSCInv_shell(InvOperatorShell):
         if self._options.hasName('innerLSCsolver_BTinvBt_ksp_constant_null_space'):
             self.const_null_space.remove(x_tmp)
         self.kspBQinvBt.solve(tmp1,y)
-        
+        assert numpy.isnan(y.norm())==False, "Applying the schur complement \
+resulted in not-a-number."
+
     def _constructBQinvBt(self):
         """ Private method repsonsible for building BQinvBt """
         self.Qv_inv = petsc_create_diagonal_inv_matrix(self.Qv)
         QinvBt = self.Qv_inv.matMult(self.Bt)
         self.BQinvBt = self.B.matMult(QinvBt)
 
-    
 class MatrixShell(ProductOperatorShell):
     """ A shell class for a matrix. """
     def __init__(self,A):
@@ -1039,13 +1040,15 @@ class Sp_shell(InvOperatorShell):
         if self.constNullSpace:
             self.const_null_space.remove(tmp1)
         self.kspSp.solve(tmp1,y)
+        assert numpy.isnan(y.norm())==False, "Applying the schur complement \
+resulted in not-a-number."
+
 
     def _create_Sp(self):
         self.A00_inv = petsc_create_diagonal_inv_matrix(self.A00)
         A00_invBt = self.A00_inv.matMult(self.A01)
         self.Sp = self.A10.matMult(A00_invBt)
         self.Sp.aypx(-1.,self.A11)
-    
 
 class TwoPhase_PCDInv_shell(InvOperatorShell):
     r""" Shell class for the two-phase PCD preconditioner.  The
@@ -1183,6 +1186,8 @@ class TwoPhase_PCDInv_shell(InvOperatorShell):
 
         self.kspAp_rho.solve(tmp2, tmp3)
         y.axpy(1.,tmp3)
+        assert numpy.isnan(y.norm())==False, "Applying the schur complement \
+resulted in not-a-number."
 
 def l2Norm(x):
     """

--- a/proteus/LinearSolvers.py
+++ b/proteus/LinearSolvers.py
@@ -1438,7 +1438,11 @@ class ModelInfo(object):
 
 class SchurPrecon(KSP_Preconditioner):
     """ Base class for PETSc Schur complement preconditioners. """
-    def __init__(self,L,prefix=None,bdyNullSpace=False):
+    def __init__(self,
+                 L,
+                 prefix=None,
+                 bdyNullSpace=False,
+                 solver_info=None):
         """
         Initializes the Schur complement preconditioner for use with PETSc.
 
@@ -1452,12 +1456,33 @@ class SchurPrecon(KSP_Preconditioner):
             Prefix identifier for command line PETSc options.
         bdyNullSpace : bool
             Flag indicating whether boundary creates nullspace.
+        solver_info: :class:`ModelInfo`
         """
         self.PCType = 'schur'
         self.L = L
-        self._initializeIS(prefix)
+        self._initializePC(prefix)
+
+        if solver_info==None:
+            self._initialize_without_solver_info()
+        else:
+            self.model_info = solver_info
+
+        self._initializeIS()
         self.bdyNullSpace = bdyNullSpace
         self.pc.setFromOptions()
+
+    def _initialize_without_solver_info(self):
+        """
+        Initializes the ModelInfo needed to create a Schur Complement
+        preconditioner.
+        """
+        nc = self.L.pde.nc
+        if len(self.L.pde.u[0].dof) == len(self.L.pde.u[1].dof):
+            self.model_info = ModelInfo(nc,'interlaced')
+        else:
+            self.model_info = ModelInfo(nc,
+                                        'blocked',
+                                        self.L.pde.u[0].dof.size)
 
     def setUp(self,global_ksp):
         """
@@ -1503,53 +1528,42 @@ class SchurPrecon(KSP_Preconditioner):
         global_ksp.pc.getFieldSplitSubKSP()[1].pc.setType('python')
         global_ksp.pc.getFieldSplitSubKSP()[1].pc.setPythonContext(self.matcontext_inv)
         global_ksp.pc.getFieldSplitSubKSP()[1].pc.setUp()
-        
 
-    def _initializeIS(self,prefix):
-        """ Sets the index set (IP) for the pressure and velocity 
-        
+    def _initializePC(self,
+                      prefix):
+        r"""
+        Intiailizes the PETSc precondition.
+
         Parameters
         ----------
         prefix : str
             Prefix identifier for command line PETSc options.
         """
-        L_sizes = self.L.getSizes()
-        L_range = self.L.getOwnershipRange()
-        neqns = L_sizes[0][0]
-        nc = self.L.pde.nc
-        rank = p4pyPETSc.COMM_WORLD.rank
-        size = p4pyPETSc.COMM_WORLD.size
-        pSpace = self.L.pde.u[0].femSpace
-        pressure_offsets = pSpace.dofMap.dof_offsets_subdomain_owned
-        n_DOF_pressure = pressure_offsets[rank+1] - pressure_offsets[rank]
-        N_DOF_pressure = pressure_offsets[size]
-        if self.L.pde.stride[0] == 1:#assume end to end
-            self.pressureDOF = numpy.arange(start=L_range[0],
-                                            stop=L_range[0]+n_DOF_pressure,
-                                            dtype="i")
-            self.velocityDOF = numpy.arange(start=L_range[0]+n_DOF_pressure,
-                                            stop=L_range[0]+neqns,
-                                            step=1,
-                                            dtype="i")
-        else: #assume blocked
-            self.pressureDOF = numpy.arange(start=L_range[0],
-                                            stop=L_range[0]+neqns,
-                                            step=nc,
-                                            dtype="i")
-            velocityDOF = []
-            for start in range(1,nc):
-                velocityDOF.append(numpy.arange(start=L_range[0]+start,
-                                                stop=L_range[0]+neqns,
-                                                step=nc,
-                                                dtype="i"))
-            self.velocityDOF = numpy.vstack(velocityDOF).transpose().flatten()
         self.pc = p4pyPETSc.PC().create()
         self.pc.setOptionsPrefix(prefix)
         self.pc.setType('fieldsplit')
+
+    def _initializeIS(self):
+        r"""Sets the index set (IP) for the pressure and velocity
+
+        Notes
+        -----
+        Proteus orders unknown degrees of freedom for saddle point
+        problems as blocked or end-to-end. Blocked systems are used
+        for equal order finite element spaces (e.g. P1-P1).  In this
+        case, the degrees of freedom are interlaced (e.g. p[0], u[0],
+        v[0], p[1], u[1], v[1], ...).
+        """
+        L_sizes = self.L.getSizes()
+        L_range = self.L.getOwnershipRange()
+        neqns = L_sizes[0][0]
+        dof_arrays = self.model_info.dof_order_type.create_DOF_lists(L_range,
+                                                                     neqns,
+                                                                     self.model_info.nc)
         self.isp = p4pyPETSc.IS()
-        self.isp.createGeneral(self.pressureDOF,comm=p4pyPETSc.COMM_WORLD)
+        self.isp.createGeneral(dof_arrays[1],comm=p4pyPETSc.COMM_WORLD)
         self.isv = p4pyPETSc.IS()
-        self.isv.createGeneral(self.velocityDOF,comm=p4pyPETSc.COMM_WORLD)
+        self.isv.createGeneral(dof_arrays[0],comm=p4pyPETSc.COMM_WORLD)
         self.pc.setFieldSplitIS(('velocity',self.isv),('pressure',self.isp))
 
     def _converged_trueRes(self,ksp,its,rnorm):
@@ -1617,24 +1631,26 @@ class Schur_Sp(SchurPrecon):
                  L,
                  prefix,
                  bdyNullSpace=False,
-                 constNullSpace=True):
-        SchurPrecon.__init__(self,L,prefix,bdyNullSpace)
-        self.operator_constructor = SchurOperatorConstructor(self)
-        self.constNullSpace = constNullSpace
+                 solver_info = None):
+        SchurPrecon.__init__(self,
+                             L,
+                             prefix,
+                             bdyNullSpace,
+                             solver_info=solver_info)
 
     def setUp(self,global_ksp):
         self._setSchurlog(global_ksp)
         if self.bdyNullSpace is True:
             self._setConstantPressureNullSpace(global_ksp)
-        self.A00 = global_ksp.getOperators()[0].getSubMatrix(self.operator_constructor.linear_smoother.isv,
-                                                             self.operator_constructor.linear_smoother.isv)
-        self.A01 = global_ksp.getOperators()[0].getSubMatrix(self.operator_constructor.linear_smoother.isv,
-                                                             self.operator_constructor.linear_smoother.isp)
-        self.A10 = global_ksp.getOperators()[0].getSubMatrix(self.operator_constructor.linear_smoother.isp,
-                                                             self.operator_constructor.linear_smoother.isv)
-        self.A11 = global_ksp.getOperators()[0].getSubMatrix(self.operator_constructor.linear_smoother.isp,
-                                                             self.operator_constructor.linear_smoother.isp)
-        L_sizes = self.operator_constructor.linear_smoother.isp.sizes
+        self.A00 = global_ksp.getOperators()[0].getSubMatrix(self.isv,
+                                                             self.isv)
+        self.A01 = global_ksp.getOperators()[0].getSubMatrix(self.isv,
+                                                             self.isp)
+        self.A10 = global_ksp.getOperators()[0].getSubMatrix(self.isp,
+                                                             self.isv)
+        self.A11 = global_ksp.getOperators()[0].getSubMatrix(self.isp,
+                                                             self.isp)
+        L_sizes = self.isp.sizes
         self.Sp_shell = p4pyPETSc.Mat().create()
         self.Sp_shell.setSizes(L_sizes)
         self.Sp_shell.setType('python')
@@ -1642,7 +1658,7 @@ class Schur_Sp(SchurPrecon):
                                        self.A11,
                                        self.A01,
                                        self.A10,
-                                       constNullSpace = self.constNullSpace)
+                                       constNullSpace = self.bdyNullSpace)
         self.Sp_shell.setPythonContext(self.matcontext_inv)
         self.Sp_shell.setUp()
         # Set PETSc Schur operator

--- a/proteus/tests/solver_tests/test_dof_order_routines.py
+++ b/proteus/tests/solver_tests/test_dof_order_routines.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""
+Test module for routines that manage dof order
+"""
+from proteus import LinearSolvers as LS
+import numpy as np
+import pytest
+
+@pytest.mark.parametrize("ownership_range,num_components",[
+    ((5,25), 3),
+    ((6,17), 4),
+    ])
+def test_interlaced_dof_order(ownership_range,
+                              num_components):
+    interlaced = LS.InterlacedDofOrderType()
+
+    num_equations = ownership_range[1] - ownership_range[0] +1
+    velocity, pressure = interlaced.create_DOF_lists(ownership_range,
+                                                     num_equations,
+                                                     num_components)
+    idx_range = np.arange(ownership_range[0],ownership_range[1]+1)
+    pressure_idx = np.arange(ownership_range[0],
+                             ownership_range[1],
+                             num_components)
+    velocity_mask = np.ones(len(idx_range),dtype='bool')
+
+    velocity_mask[pressure_idx -ownership_range[0]] = 0
+    assert np.array_equal(pressure_idx, pressure)
+    assert np.array_equal(idx_range[velocity_mask],
+                          velocity)
+
+@pytest.mark.parametrize("ownership_range,num_components,n_DOF_pressure",[
+    ((5,25), 3, 7),
+    ((6,17), 4, 3),
+    ])
+def test_blocked_dof_order(ownership_range,
+                           num_components,
+                           n_DOF_pressure):
+    array_start = ownership_range[0]
+    array_end = ownership_range[1]
+
+    blocked = LS.BlockedDofOrderType(n_DOF_pressure)
+    num_equations = array_end - array_start + 1
+
+    velocity, pressure = blocked.create_DOF_lists(ownership_range,
+                                                  num_equations,
+                                                  num_components)
+    pressure_idx = np.arange(array_start,
+                             array_start + n_DOF_pressure)
+    velocity_idx = np.arange(pressure_idx[-1] + 1,
+                             array_end + 1)
+    assert np.array_equal(pressure_idx, pressure)
+    assert np.array_equal(velocity_idx, velocity)

--- a/proteus/tests/solver_tests/test_iterative_methods.py
+++ b/proteus/tests/solver_tests/test_iterative_methods.py
@@ -13,7 +13,7 @@ from proteus import LinearSolvers as LS
 import os
 import sys
 import inspect
-import petsc4py
+import petsc4py as p4pyPETSc
 import numpy as np
 import pytest
 import pickle
@@ -22,6 +22,133 @@ from petsc4py import PETSc as p4pyPETSc
 
 proteus.test_utils.TestTools.addSubFolders( inspect.currentframe() )
 
+def create_petsc_vecs(matrix_A):
+    """
+    Creates a right-hand-side and solution PETSc4Py vector for
+    testing ksp solves.
+
+    Parameters
+    ----------
+    matrix_A: :class:`p4pyPETSc.Mat`
+        Global matrix object
+
+    Returns
+    -------
+    vec_lst: tuple
+        This is a list of :class:`pypyPETSc.Vec` where the first is
+        a vector of ones (usually to act as a RHS-vector) while the
+        second vector is a vector of zeros (usually to act as a
+        storage vector for the solution).
+    """
+    b = p4pyPETSc.Vec().create()
+    x = p4pyPETSc.Vec().create()
+    b.createWithArray(np.ones(matrix_A.getSizes()[0][0]))
+    x.createWithArray(np.zeros(matrix_A.getSizes()[0][0]))
+    return (b, x)
+
+def initialize_schur_ksp_obj(matrix_A, schur_approx):
+    """
+    Creates a right-hand-side and solution PETSc4Py vector for
+    testing ksp solves.
+
+    Parameters
+    ----------
+    matrix_A: :class:`p4pyPETSc.Mat`
+        Global matrix object.
+    schur_approx: :class:`LS.SchurPrecon`
+
+    Returns
+    -------
+    ksp_obj: :class:`p4pyPETSc.KSP`
+    """
+    ksp_obj = p4pyPETSc.KSP().create()
+    ksp_obj.setOperators(matrix_A,matrix_A)
+    pc = schur_approx.pc
+    ksp_obj.setPC(pc)
+    ksp_obj.setFromOptions()
+    pc.setFromOptions()
+    pc.setOperators(matrix_A,matrix_A)
+    pc.setUp()
+    schur_approx.setUp(ksp_obj)
+    ksp_obj.setUp()
+    ksp_obj.pc.setUp()
+    return ksp_obj
+
+@pytest.fixture()
+def initialize_petsc_options(request):
+    """Initializes schur complement petsc options. """
+    petsc_options = p4pyPETSc.Options()
+    petsc_options.setValue('ksp_type','gmres')
+    petsc_options.setValue('ksp_gmres_restart',500)
+    petsc_options.setValue('ksp_atol',1e-20)
+    petsc_options.setValue('ksp_gmres_modifiedgramschmidt','')
+    petsc_options.setValue('pc_fieldsplit_type','schur')
+    petsc_options.setValue('pc_fieldsplit_schur_fact_type','upper')
+    petsc_options.setValue('pc_fieldsplit_schur_precondition','user')
+    petsc_options.setValue('fieldsplit_velocity_ksp_type','preonly')
+    petsc_options.setValue('fieldsplit_velocity_pc_type', 'lu')
+    petsc_options.setValue('fieldsplit_pressure_ksp_type','preonly')
+
+@pytest.fixture()
+def load_nse_cavity_matrix(request):
+    """Loads a Navier-Stokes matrix drawn from the MPRANS module. """
+    A = LAT.petsc_load_matrix(os.path.join
+                              (os.path.dirname(__file__),'NSE_cavity_matrix'))
+    yield A
+
+@pytest.fixture()
+def load_nse_step_matrix(request):
+    """
+    Loads a Navier-Stokes matrix for the backwards step problem from
+    the MPRANS module.  This matrix is constructed using no-slip
+    boundary conditions, and weakly enforced Dirichlet conditions.
+    """
+    A = LAT.petsc_load_matrix(os.path.join
+                              (os.path.dirname(__file__),'NSE_step_no_slip'))
+    yield A
+
+@pytest.mark.LinearSolvers
+def test_Schur_Sp_solve_global_null_space(load_nse_cavity_matrix,
+                                          initialize_petsc_options):
+    """Tests a KSP solve using the Sp Schur complement approximation.
+    For this test, the global matrix has a null space because the
+    boundary conditions are pure Dirichlet. """
+    mat_A = load_nse_cavity_matrix
+    b, x = create_petsc_vecs(mat_A)
+    petsc_options = initialize_petsc_options
+
+    solver_info = LS.ModelInfo(3,'interlaced')
+    schur_approx = LS.Schur_Sp(mat_A,
+                               '',
+                               True,
+                               solver_info=solver_info)
+    ksp_obj = initialize_schur_ksp_obj(mat_A,schur_approx)
+    ksp_obj.solve(b,x)
+
+    assert ksp_obj.converged == True
+    assert ksp_obj.its == 35
+    assert np.allclose(ksp_obj.norm, 0.0007464632)
+    assert ksp_obj.reason == 2
+
+@pytest.mark.LinearSolvers
+def test_Schur_Sp_solve(load_nse_step_matrix,
+                        initialize_petsc_options):
+    """Tests a KSP solve using the Sp Schur complement approximation.
+       For this test, the global matrix does not have a null space."""
+    mat_A = load_nse_step_matrix
+    b, x = create_petsc_vecs(mat_A)
+
+    solver_info = LS.ModelInfo(3, 'interlaced')
+    schur_approx = LS.Schur_Sp(mat_A,
+                               '',
+                               solver_info=solver_info)
+    ksp_obj = initialize_schur_ksp_obj(mat_A, schur_approx)
+    ksp_obj.solve(b,x)
+
+    assert ksp_obj.converged == True
+    assert ksp_obj.its == 45
+    assert np.allclose(ksp_obj.norm, 394.7036050627)
+    assert ksp_obj.reason == 2
 
 class TestIterativeMethods(proteus.test_utils.TestTools.BasicTest):
 
@@ -85,6 +212,6 @@ class TestIterativeMethods(proteus.test_utils.TestTools.BasicTest):
         expected = np.load(os.path.join(self._scriptdir,'import_modules/sol_20_lst.npy'))
         for i,item in enumerate(expected):
             assert np.allclose(item,solver.iteration_results[i],1e-12)
-        
+
 if __name__ == '__main__':
     pass

--- a/proteus/tests/solver_tests/test_operator_shells.py
+++ b/proteus/tests/solver_tests/test_operator_shells.py
@@ -21,6 +21,106 @@ from scipy.sparse import csr_matrix
 
 proteus.test_utils.TestTools.addSubFolders( inspect.currentframe() )
 
+@pytest.fixture()
+def create_simple_saddle_point_problem(request):
+    """Builds simple matrices and vectors for saddle point shell tests.
+
+    Returns
+    -------
+    output_lst : lst
+        This function returns an output list with three sublists.  See
+        the notes below for a description of these lists.
+
+    Notes
+    -----
+    The output of this function returns xxx sublists.  The first
+    contains a list of matrices.  The second returns a list
+    of vectors.  The last returns a list of sizes.
+    """
+    class Output_Storage(object):
+        """Storage class for matrix objects. """
+        def __init__(self,
+                     petsc_matF,
+                     petsc_matD,
+                     petsc_matB,
+                     petsc_matBt,
+                     petsc_matC,
+                     x_vec,
+                     y_vec,
+                     num_p_unkwn,
+                     num_v_unkwn):
+            self.petsc_matF = petsc_matF
+            self.petsc_matD = petsc_matD
+            self.petsc_matB = petsc_matB
+            self.petsc_matBt = petsc_matBt
+            self.petsc_matC = petsc_matC
+            self.x_vec = x_vec
+            self.y_vec = y_vec
+            self.num_p_unkwn = num_p_unkwn
+            self.num_v_unkwn = num_v_unkwn
+
+    vals_F  =    [3.2, 1.1, 6.3, 1., -5.1]
+    col_idx_F  = [0, 1, 0, 2, 0]
+    row_idx_F  = [0, 2, 4, 5]
+
+    vals_D =     [5.5,7.1,1.0]
+    col_idx_D =  [0 , 1 , 2  ]
+    row_idx_D =  [0, 1, 2, 3]
+
+    vals_B    =  [1.1, 6.3, 7.3, 3.6, 6.3]
+    col_idx_B =  [0  , 2  , 0  , 1  , 2  ]
+    row_idx_B =  [0, 2, 5]
+
+    vals_Bt   =  [1.1, 7.3, 3.6, 6.3, 6.3]
+    col_idx_Bt = [0, 1, 1, 0, 1]
+    row_idx_Bt = [0, 2, 3, 5]
+
+    vals_C = [1.2, 2.1, 3.3]
+    col_idx_C = [0, 1, 1]
+    row_idx_C = [0, 2, 3]
+
+    num_p_unkwn = len(row_idx_B) - 1
+    num_v_unkwn = len(row_idx_F) - 1
+
+    petsc_matF = LAT.csr_2_petsc(size = (num_v_unkwn,num_v_unkwn),
+                                 csr = (row_idx_F,col_idx_F,vals_F))
+    petsc_matD = LAT.csr_2_petsc(size = (num_v_unkwn,num_v_unkwn),
+                                 csr = (row_idx_D,col_idx_D,vals_D))
+    petsc_matB = LAT.csr_2_petsc(size = (num_p_unkwn,num_v_unkwn),
+                                 csr = (row_idx_B,col_idx_B,vals_B))
+    petsc_matBt = LAT.csr_2_petsc(size = (num_v_unkwn,num_p_unkwn),
+                                  csr = (row_idx_Bt,col_idx_Bt,vals_Bt))
+    petsc_matC = LAT.csr_2_petsc(size = (num_p_unkwn,num_p_unkwn),
+                                 csr = (row_idx_C,col_idx_C,vals_C))
+
+    x_vec = np.ones(num_p_unkwn)
+    y_vec = np.zeros(num_p_unkwn)
+    x_PETSc_vec = p4pyPETSc.Vec().createWithArray(x_vec)
+    y_PETSc_vec = p4pyPETSc.Vec().createWithArray(y_vec)
+
+    output_data = Output_Storage(petsc_matF,
+                                 petsc_matD,
+                                 petsc_matB,
+                                 petsc_matBt,
+                                 petsc_matC,
+                                 x_PETSc_vec,
+                                 y_PETSc_vec,
+                                 num_p_unkwn,
+                                 num_v_unkwn)
+
+    yield output_data
+
+def setup_LSC_shell(petsc_options, fixture_data):
+    petsc_options.setValue('innerLSCsolver_BTinvBt_ksp_type','preonly')
+    petsc_options.setValue('innerLSCsolver_T_ksp_type','preonly')
+    petsc_options.setValue('innerLSCsolver_BTinvBt_pc_type','lu')
+    petsc_options.setValue('innerLSCsolver_T_pc_type','lu')
+
+    return LAT.LSCInv_shell(fixture_data.petsc_matD,
+                            fixture_data.petsc_matB,
+                            fixture_data.petsc_matBt,
+                            fixture_data.petsc_matF)
+
 @pytest.mark.LinearAlgebraTools
 class TestOperatorShells(proteus.test_utils.TestTools.BasicTest):
 
@@ -40,51 +140,21 @@ class TestOperatorShells(proteus.test_utils.TestTools.BasicTest):
         for element in rm_lst:
             self.petsc_options.delValue(element)
 
-    def test_lsc_shell(self):
+    def test_lsc_shell(self, create_simple_saddle_point_problem):
         ''' Test for the lsc operator shell '''
-        vals_A =     [5.5,7.1,1.0]
-        col_idx_A =  [0 , 1 , 2  ]
-        row_idx_A =  [0, 1, 2, 3]
-        vals_B    =  [1.1, 6.3, 7.3, 3.6, 6.3]
-        col_idx_B =  [0  , 2  , 0  , 1  , 2  ]
-        row_idx_B =  [0, 2, 5]
-        vals_Bt   =  [1.1, 7.3, 3.6, 6.3, 6.3]
-        col_idx_Bt = [0, 1, 1, 0, 1]
-        row_idx_Bt = [0, 2, 3, 5]
-        vals_F  =    [3.2, 1.1, 6.3, 1., -5.1]
-        col_idx_F  = [0, 1, 0, 2, 0]
-        row_idx_F  = [0, 2, 4, 5]
-        num_B_rows = len(row_idx_B) - 1
-        num_B_cols = len(row_idx_A) - 1
+        fixture_data = create_simple_saddle_point_problem
 
-        petsc_matA = LAT.csr_2_petsc(size = (num_B_cols,num_B_cols),
-                                     csr = (row_idx_A,col_idx_A,vals_A))
-        petsc_matB = LAT.csr_2_petsc(size = (num_B_rows,num_B_cols), 
-                                     csr = (row_idx_B,col_idx_B,vals_B))
-        petsc_matBt = LAT.csr_2_petsc(size = (num_B_cols,num_B_rows), 
-                                      csr = (row_idx_Bt,col_idx_Bt,vals_Bt))
-        petsc_matF = LAT.csr_2_petsc(size = (num_B_cols,num_B_cols), 
-                                     csr = (row_idx_F,col_idx_F,vals_F))
-
-        self.petsc_options.setValue('innerLSCsolver_BTinvBt_ksp_type','preonly')
-        self.petsc_options.setValue('innerLSCsolver_T_ksp_type','preonly')
-        self.petsc_options.setValue('innerLSCsolver_BTinvBt_pc_type','lu')
-        self.petsc_options.setValue('innerLSCsolver_T_pc_type','lu')
-        LSC_shell = LAT.LSCInv_shell(petsc_matA,
-                                     petsc_matB,
-                                     petsc_matBt,
-                                     petsc_matF)
-        x_vec = np.ones(num_B_rows)
-        y_vec = np.zeros(num_B_rows)
-        x_PETSc_vec = p4pyPETSc.Vec().createWithArray(x_vec)
-        y_PETSc_vec = p4pyPETSc.Vec().createWithArray(y_vec)
-        A = None
-        LSC_shell.apply(A,x_PETSc_vec,y_PETSc_vec)
+        LSC_shell = setup_LSC_shell(self.petsc_options,
+                                    fixture_data)
+        LSC_shell.apply(None,
+                        fixture_data.x_vec,
+                        fixture_data.y_vec)
         true_solu = np.mat('[-0.01096996,0.00983216]')
-        assert np.allclose(y_vec,true_solu)
+        assert np.allclose(fixture_data.y_vec.getArray(),
+                           true_solu)
 
     def test_tppcd_shell(self):
-        ''' Test for the lsc operator shell '''
+        ''' Test for the two-phase pcd operator shell '''
         Qp_visc = LAT.petsc_load_matrix(os.path.join(self._scriptdir,'import_modules/Qp_visc'))
         Qp_dens = LAT.petsc_load_matrix(os.path.join(self._scriptdir,'import_modules/Qp_dens'))
         Ap_rho = LAT.petsc_load_matrix(os.path.join(self._scriptdir, 'import_modules/Ap_rho'))
@@ -110,7 +180,6 @@ class TestOperatorShells(proteus.test_utils.TestTools.BasicTest):
         TPPCD_shell.apply(A,x_vec,y_vec)
         true_solu = LAT.petsc_load_vector(os.path.join(self._scriptdir, 'import_modules/tp_pcd_y_output'))
         assert np.allclose(y_vec.getArray(),true_solu.getArray())
-        
-        
+
 if __name__ == '__main__':
     pass

--- a/proteus/tests/solver_tests_slow/test_nseDC_THQuad_2D.py
+++ b/proteus/tests/solver_tests_slow/test_nseDC_THQuad_2D.py
@@ -50,6 +50,7 @@ class Test_NSE_Driven_Cavity(proteus.test_utils.TestTools.SimulationTest):
         relpath = 'comparison_files/drivenCavityNSE_LSC_expected.h5'
         expected = tables.open_file(os.path.join(self._scriptdir,relpath))
         actual = tables.open_file('drivenCavityNSETrial.h5','r')
+
         assert numpy.allclose(expected.root.velocity_t7,
                               actual.root.velocity_t7,
                               atol=1e-2)


### PR DESCRIPTION
     * The DofOrderInfo classes are intended to organize and manage
       the DOF ordering for saddle point systems with pressure and
       velocity unknowns.

     * Currently, there are two classes one for blocked ordering (this
       appears for TH elements) and one for interlaced ordering (this
       appears for P1-P1 elements).

     * Adds a couple of basic tests for DofOrderInfo class.