### PR TITLE
WaveTools: SteadyCurrent fix

### DIFF
--- a/proteus/WaveTools.py
+++ b/proteus/WaveTools.py
@@ -727,7 +727,7 @@ class  SteadyCurrent:
             Free-surface elevation as a float
 
         """
-        return  self.mwl
+        return 0.
     def u(self,x,t):
         """Calculates wave velocity vector (SolitaryWave class).
         Parameters

--- a/proteus/tests/wave_tests/test_wavetools.py
+++ b/proteus/tests/wave_tests/test_wavetools.py
@@ -393,13 +393,13 @@ class VerifySteadyCurrent(unittest.TestCase):
         # no ramptime
         WW = SteadyCurrent(U,mwl)
         self.assertAlmostEqual(U.all(), WW.u(xx,t).all())
-        self.assertAlmostEqual(mwl, WW.eta(xx,t))
+        self.assertAlmostEqual(0., WW.eta(xx,t))
 
         # with ramp
         Up = 0.5*U
         WW = SteadyCurrent(U,mwl,0.2)
         self.assertAlmostEqual(Up.all(), WW.u(xx,t).all())
-        self.assertAlmostEqual(mwl, WW.eta(xx,t))
+        self.assertAlmostEqual(0., WW.eta(xx,t))
 
         
         


### PR DESCRIPTION
A small fix for the `SteadyCurrent` class in WaveTools where `eta` is set to `0` instead of `mwl` so the mprans.BoundaryConditions module imposes the VOF correctly in `setUnsteadyTwoPhaseVelocityInlet`.
@cekees @adimako 