### PR TITLE
fix stepExact=False case for Sequential_MinAdaptiveModelStep

### DIFF
--- a/proteus/SplitOperator.py
+++ b/proteus/SplitOperator.py
@@ -17,7 +17,7 @@ class SO_base:
 
     The base class implements sequential splitting with a fixed time
     step based on the input parameter `default_so.dt_system`. If
-    `default_so.stepExactSystem` is True then the time step will be
+    `default_so.systemStepExact` is True then the time step will be
     reduced when needed to match the output times in
     `default_so.tnList`, otherwise the output will be the first time
     step after each step in `tnList`.

--- a/proteus/SplitOperator.py
+++ b/proteus/SplitOperator.py
@@ -325,7 +325,7 @@ class Sequential_MinModelStep(SO_base):
     def initialize_dt_system(self,t0,tOut):
         self.its=0
         self.t_system_last = t0
-        self.dt_system = min([model.stepController.dt_model for model in self.modelList])
+        self.dt_system = min(min([model.stepController.dt_model for model in self.modelList]),tOut-t0)
         self.t_system = self.t_system_last + self.dt_system
         self.stepSequence=[(self.t_system,m) for m in self.modelList]
         for model in self.modelList:
@@ -514,7 +514,7 @@ class Sequential_MinAdaptiveModelStep(SO_base):
     def initialize_dt_system(self,t0,tOut):
         self.its=0
         self.t_system_last = t0
-        self.dt_system = min([model.stepController.dt_model for model in self.controllerList])
+        self.dt_system = min(tOut-t0,min([model.stepController.dt_model for model in self.controllerList]))
         self.t_system = self.t_system_last + self.dt_system
         self.stepSequence=[(self.t_system,m) for m in self.modelList]
         for model in self.modelList:

--- a/scripts/parun
+++ b/scripts/parun
@@ -349,6 +349,10 @@ elif len(args) == 2: #p and n modules provided
     except:
         pass
     try:
+        so.systemStepExact = nList[0].systemStepExact
+    except:
+        pass
+    try:
         so.tnList = nList[0].tnList
         so.archiveFlag = nList[0].archiveFlag
     except:


### PR DESCRIPTION
The `systemStepExact` option in the so-file input controls whether the adaptive time stepping steps exactly to the user-defined steps in tnList. While the `stepExact=True` case safeguards against taking very small times steps, the VMS tau formula we use  is a function of the step size, which can result in significant perturbations of integral quantities like draft and lift. Setting `systemStepExact=False` allows smoother variation of the time step but doesn't archive exactly at the steps in tnList. This PR fixes the initial time step size for adaptive time stepping by using tnList[1], but after that will ignore the tnList for the purpose of time step selection. I also added a hook in parun to grab `systemStepExact` from the n-file instead of the so-file (e.g. for using it on simple problems like the cylinder @wacyyang ). @tridelat and @adimako I noticed in the input files I got from @tridelat that the non-exisitent `stepExactSystem` was being set. Using `systemStepExact=False`  may fix some pressure gauge noise that @Giovanni-Cozzuto-1989 has found. 

@manuel-quezada I did verify that removing the dt term from the SUPG formulas also fixes the problem, but I didn't have time to test it more generally. Might be worth looking at these oscillations in the RANS3P code where we can compare to EV.