### PR TITLE
Submodule updated with shorter tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "air-water-vv"]
 	path = air-water-vv
-	url = https://github.com/Pedrohrw/air-water-vv.git
-	branch = master
+	url = https://github.com/erdc/air-water-vv.git
+	branch = pom-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 
 script:
 - py.test --boxed -v linux2/lib/python2.7/site-packages/proteus-$(python -c "import proteus; print proteus.__version__")-py2.7-linux-x86_64.egg/proteus/tests --cov=linux2/lib/python2.7/site-packages/proteus-$(python -c "import proteus; print proteus.__version__")-py2.7-linux-x86_64.egg/proteus
-- py.test --boxed -v air-water-vv/Tests/test_dambreak_Colagrossi.py
+- py.test --boxed -v air-water-vv/Tests/
 
 notifications:
   email:


### PR DESCRIPTION
At this time, The submodule has been updated. Now, this submodule is pointing at the branch "pom-tests" at the air-water-vv repository. Moreover, the air-water-vv tests that will be run by Travis every time we make a pull request in proteus repository are shorter. I reduced the duration of the simulation in order to try to addapt to Travis limit time.
This change is provisional, since the submodule has to point in the master branch of the air-water-vv tests in the end. In the branch "pom-tests" in the air-water-vv repository I have removed the .travis.yaml file, since the air-water-vv tests will be run in the proteus submodule togheter with proteus.
I was discussing about this with @adimako, but it is not completely sure.

So, we have to decide what is the best way to test all these cases.