### PR TITLE
advective penalty flux for non-conservative form

### DIFF
--- a/proteus/mprans/BoundaryConditions.py
+++ b/proteus/mprans/BoundaryConditions.py
@@ -586,6 +586,17 @@ class BC_RANS(BoundaryConditions.BC_Base):
                                             -
                                             smoothedHeaviside_integral(smoothing, phi)))
 
+        def diffusiveFlux_u(x,t):
+            g = hydrostaticPressureOutletWithDepth_p_dirichlet(x,t)
+            phi = x[vert_axis] - seaLevel
+            if phi >= smoothing:
+                H = 1.
+            elif smoothing > 0 and -smoothing < phi < smoothing:
+                H = smoothedHeaviside(smoothing, phi)
+            elif phi <= -smoothing:
+                H = 0.
+            return H*(1.500e-5*1.205)*g + (1-H)*(1.004e-6*998.2)*g
+
         def hydrostaticPressureOutletWithDepth_vof_dirichlet(x, t):
             phi = x[vert_axis] - seaLevel
             if phi >= smoothing:
@@ -621,7 +632,9 @@ class BC_RANS(BoundaryConditions.BC_Base):
         self.w_dirichlet.setConstantBC(0.)
         self.p_dirichlet.uOfXT = hydrostaticPressureOutletWithDepth_p_dirichlet
         self.vof_dirichlet.uOfXT = hydrostaticPressureOutletWithDepth_vof_dirichlet
-        self.u_diffusive.setConstantBC(0.)
+        self.u_diffusive.uOfXT = diffusiveFlux_u
+        self.v_diffusive.setConstantBC(0.)
+#        self.u_diffusive.setConstantBC(0.)
         self.k_diffusive.setConstantBC(0.)
         self.dissipation_diffusive.setConstantBC(0.)
 

--- a/proteus/mprans/BoundaryConditions.py
+++ b/proteus/mprans/BoundaryConditions.py
@@ -586,6 +586,116 @@ class BC_RANS(BoundaryConditions.BC_Base):
                                             -
                                             smoothedHeaviside_integral(smoothing, phi)))
 
+        def hydrostaticPressureOutletWithDepth_vof_dirichlet(x, t):
+            phi = x[vert_axis] - seaLevel
+            if phi >= smoothing:
+                H = 1.
+            elif smoothing > 0 and -smoothing < phi < smoothing:
+                H = smoothedHeaviside(smoothing, phi)
+            elif phi <= -smoothing:
+                H = 0.
+            return H * air + (1 - H) * water
+
+        def inlet_k_dirichlet(x, t):
+            phi = x[vert_axis] - seaLevel
+            if phi <= 0.:
+                H = 0.0
+            elif 0 < phi <= smoothing:
+                H = smoothedHeaviside(smoothing / 2., phi - smoothing / 2.)
+            else:
+                H = 1.0
+            return H * kInflowAir + (1 - H) * kInflow
+
+        def inlet_dissipation_dirichlet(x, t):
+            phi = x[vert_axis] - seaLevel
+            if phi <= 0.:
+                H = 0.0
+            elif 0 < phi <= smoothing:
+                H = smoothedHeaviside(smoothing / 2., phi - smoothing / 2.)
+            else:
+                H = 1.0
+            return H * dissipationInflowAir + (1 - H) * dissipationInflow
+
+        self.u_dirichlet.setConstantBC(0.)
+        self.v_dirichlet.setConstantBC(0.)
+        self.w_dirichlet.setConstantBC(0.)
+        self.p_dirichlet.uOfXT = hydrostaticPressureOutletWithDepth_p_dirichlet
+        self.vof_dirichlet.uOfXT = hydrostaticPressureOutletWithDepth_vof_dirichlet
+        self.u_diffusive.setConstantBC(0.)
+        self.k_diffusive.setConstantBC(0.)
+        self.dissipation_diffusive.setConstantBC(0.)
+
+        if U is not None:
+            def get_inlet_ux_dirichlet(i):
+                def ux_dirichlet(x, t):
+                    phi = x[vert_axis] - seaLevel
+                    if phi <= 0.:
+                        H = 0.0
+                    elif 0 < phi <= smoothing:
+                        H = smoothedHeaviside(smoothing / 2., phi - smoothing / 2.)
+                    else:
+                        H = 1.0
+                    return H * Uwind[i] + (1 - H) * U[i]
+                return ux_dirichlet
+
+            if Uwind is None:
+                Uwind = np.zeros(3)
+            U = np.array(U)
+            Uwind = np.array(Uwind)
+            self.u_dirichlet.uOfXT = get_inlet_ux_dirichlet(0)
+            self.v_dirichlet.uOfXT = get_inlet_ux_dirichlet(1)
+            self.w_dirichlet.uOfXT = get_inlet_ux_dirichlet(2)
+            self.u_diffusive.resetBC()
+
+        if kInflow is not None:
+            self.k_dirichlet.uOfXT = inlet_k_dirichlet
+            self.k_advective.resetBC()
+            self.k_diffusive.resetBC()
+        if dissipationInflow is not None:
+            self.dissipation_dirichlet.uOfXT = inlet_dissipation_dirichlet
+            self.dissipation_advective.resetBC()
+            self.dissipation_diffusive.resetBC()
+
+
+    def setHydrostaticPressureOutletWithDepth_stressFree(self, seaLevel, rhoUp, rhoDown, nuUp, nuDown, g,
+                                                         refLevel, smoothing, U=None, Uwind=None,
+                                                         pRef=0.0, vert_axis=None,
+                                                         air=1.0, water=0.0,
+                                                         kInflow=None, dissipationInflow=None,
+                                                         kInflowAir=None, dissipationInflowAir=None):
+        """
+        Returns the pressure and vof profile based on the known depth.
+        If the boundary is aligned with one of the main axes, sets the tangential
+        velocity components to zero as well.
+        (!) This condition is best used for boundaries and gravity aligned with
+            one of the main axes.
+
+        Parameters
+        ----------
+        rhoUp: Phase density of the upper part.
+        rhoDown: Phase density of the lower part.
+        nuUp: Phase viscosity of the upper part.
+        nuDown: Phase viscosity of the lower part.
+        g: Gravitational acceleration vector.
+        refLevel: Level at which pressure = pRef.
+        pRef: Reference value for the pressure at x[vert_axis]=refLevel, by default set to 0.
+        vert_axis: index of vertical in position vector, must always be aligned with gravity, by default set to 1.
+        """
+        self.reset()
+
+        if vert_axis is None:
+            vert_axis = self.nd - 1
+
+        def hydrostaticPressureOutletWithDepth_p_dirichlet(x, t):
+            p_top = pRef
+            phi_top = refLevel - seaLevel
+            phi = x[vert_axis] - seaLevel
+            return p_top - g[vert_axis] * (rhoDown * (phi_top - phi) +
+                                           (rhoUp - rhoDown) *
+                                           (smoothedHeaviside_integral(smoothing, phi_top)
+                                            -
+                                            smoothedHeaviside_integral(smoothing, phi)))
+
         def diffusiveFlux_u(x,t):
             g = hydrostaticPressureOutletWithDepth_p_dirichlet(x,t)
             phi = x[vert_axis] - seaLevel
@@ -595,7 +705,7 @@ class BC_RANS(BoundaryConditions.BC_Base):
                 H = smoothedHeaviside(smoothing, phi)
             elif phi <= -smoothing:
                 H = 0.
-            return H*(1.500e-5*1.205)*g + (1-H)*(1.004e-6*998.2)*g
+            return H*(nuUp*rhoUp)*g + (1-H)*(nuDown*rhoDown)*g
 
         def hydrostaticPressureOutletWithDepth_vof_dirichlet(x, t):
             phi = x[vert_axis] - seaLevel
@@ -634,7 +744,6 @@ class BC_RANS(BoundaryConditions.BC_Base):
         self.vof_dirichlet.uOfXT = hydrostaticPressureOutletWithDepth_vof_dirichlet
         self.u_diffusive.uOfXT = diffusiveFlux_u
         self.v_diffusive.setConstantBC(0.)
-#        self.u_diffusive.setConstantBC(0.)
         self.k_diffusive.setConstantBC(0.)
         self.dissipation_diffusive.setConstantBC(0.)
 
@@ -668,7 +777,6 @@ class BC_RANS(BoundaryConditions.BC_Base):
             self.dissipation_dirichlet.uOfXT = inlet_dissipation_dirichlet
             self.dissipation_advective.resetBC()
             self.dissipation_diffusive.resetBC()
-
 
 # FOLLOWING BOUNDARY CONDITION IS UNTESTED #
 

--- a/proteus/mprans/RANS2P.h
+++ b/proteus/mprans/RANS2P.h
@@ -1376,6 +1376,13 @@ namespace proteus
                 flux_vmom += n[0]*f_vmom[0];
                 flux_wmom += n[0]*f_wmom[0];
               }
+            else
+              {
+                if (NONCONSERVATIVE_FORM > 0.0)
+                  {
+                    flux_umom+=(0.0-u)*flowSpeedNormal;
+                  }
+              }
           }
         else
           {
@@ -1389,9 +1396,16 @@ namespace proteus
               }
             else
               {
-                flux_umom+=n[0]*bc_f_umom[0];
-                flux_vmom+=n[0]*bc_f_vmom[0];
-                flux_wmom+=n[0]*bc_f_wmom[0];
+	      if (NONCONSERVATIVE_FORM > 0.0)
+		{
+		  flux_umom+=(bc_u-u)*flowSpeedNormal;
+		}
+	      else
+		{
+                  flux_umom+=n[0]*bc_f_umom[0];
+                  flux_vmom+=n[0]*bc_f_vmom[0];
+                  flux_wmom+=n[0]*bc_f_wmom[0];
+                }
               }
           }
         if (isDOFBoundary_v != 1)
@@ -1403,6 +1417,13 @@ namespace proteus
                 flux_umom+=n[1]*f_umom[1];
                 flux_vmom+=n[1]*f_vmom[1];
                 flux_wmom+=n[1]*f_wmom[1];
+              }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    flux_vmom+=(0.0-v)*flowSpeedNormal;
+		  }
               }
           }
         else
@@ -1417,9 +1438,16 @@ namespace proteus
               }
             else
               {
-                flux_umom+=n[1]*bc_f_umom[1];
-                flux_vmom+=n[1]*bc_f_vmom[1];
-                flux_wmom+=n[1]*bc_f_wmom[1];
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    flux_vmom+=(bc_v-v)*flowSpeedNormal;
+		  }
+		else
+		  {
+                    flux_umom+=n[1]*bc_f_umom[1];
+                    flux_vmom+=n[1]*bc_f_vmom[1];
+                    flux_wmom+=n[1]*bc_f_wmom[1];
+                  }
               }
           }
         if (isDOFBoundary_w != 1)
@@ -1431,6 +1459,13 @@ namespace proteus
                 flux_umom+=n[2]*f_umom[2];
                 flux_vmom+=n[2]*f_vmom[2];
                 flux_wmom+=n[2]*f_wmom[2];
+              }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    flux_wmom+=(0.0-w)*flowSpeedNormal;
+		  }
               }
           }
         else
@@ -1445,9 +1480,16 @@ namespace proteus
               }
             else
               {
-                flux_umom+=n[2]*bc_f_umom[2];
-                flux_vmom+=n[2]*bc_f_vmom[2];
-                flux_wmom+=n[2]*bc_f_wmom[2];
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    flux_wmom+=(bc_w-w)*flowSpeedNormal;
+		  }
+		else
+		  {
+                    flux_umom+=n[2]*bc_f_umom[2];
+                    flux_vmom+=n[2]*bc_f_vmom[2];
+                    flux_wmom+=n[2]*bc_f_wmom[2];
+                  }
               }
           }
         if (isDOFBoundary_p == 1)
@@ -1499,6 +1541,9 @@ namespace proteus
                                                        const double& oneByRho,
                                                        const double n[nSpace],
                                                        const double& bc_p,
+                                                       const double& bc_u,
+                                                       const double& bc_v,
+                                                       const double& bc_w,
                                                        const double bc_f_mass[nSpace],
                                                        const double bc_f_umom[nSpace],
                                                        const double bc_f_vmom[nSpace],
@@ -1508,6 +1553,10 @@ namespace proteus
                                                        const double& bc_flux_vmom,
                                                        const double& bc_flux_wmom,
                                                        const double& p,
+						       const double& u,
+						       const double& v,
+						       const double& w,
+						       const double& dmom_u_acc_u,
                                                        const double f_mass[nSpace],
                                                        const double f_umom[nSpace],
                                                        const double f_vmom[nSpace],
@@ -1582,6 +1631,15 @@ namespace proteus
                 dflux_wmom_dv += n[0]*df_wmom_dv[0];
                 dflux_wmom_dw += n[0]*df_wmom_dw[0];
               }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_umom_du+=(  dmom_u_acc_u*n[0]*(0.0 - u) - flowSpeedNormal ) ;
+		    dflux_umom_dv+= dmom_u_acc_u * (0.0 - u) * n[1];
+		    dflux_umom_dw+= dmom_u_acc_u * (0.0 - u) * n[2];
+		  }
+              }
           }
         else
           {
@@ -1603,10 +1661,19 @@ namespace proteus
               }
             else
               {
-                if (isDOFBoundary_v != 1)
-                  dflux_vmom_dv += n[0]*df_vmom_dv[0];
-                if (isDOFBoundary_w != 1)
-                  dflux_wmom_dw += n[0]*df_wmom_dw[0];
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_umom_du+=(  dmom_u_acc_u*n[0]*(bc_u-u) - flowSpeedNormal ) ;
+		    dflux_umom_dv+= dmom_u_acc_u * (bc_u - u) * n[1];
+		    dflux_umom_dw+= dmom_u_acc_u * (bc_u - u) * n[2];
+		  }
+		else
+		  {
+                    if (isDOFBoundary_v != 1)
+                      dflux_vmom_dv += n[0]*df_vmom_dv[0];
+                    if (isDOFBoundary_w != 1)
+                      dflux_wmom_dw += n[0]*df_wmom_dw[0];
+                  }
               }
           }
         if (isDOFBoundary_v != 1)
@@ -1625,6 +1692,15 @@ namespace proteus
                 dflux_wmom_du += n[1]*df_wmom_du[1];
                 dflux_wmom_dv += n[1]*df_wmom_dv[1];
                 dflux_wmom_dw += n[1]*df_wmom_dw[1];
+              }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_vmom_du += dmom_u_acc_u * n[0] * (0.0 - v);
+		    dflux_vmom_dv += ( dmom_u_acc_u * n[1] * (0.0 - v) - flowSpeedNormal) ;
+		    dflux_vmom_dw += dmom_u_acc_u * n[2] * (0.0 - v);
+		  }
               }
           }
         else
@@ -1647,10 +1723,19 @@ namespace proteus
               }
             else
               {
-                if (isDOFBoundary_u != 1)
-                  dflux_umom_du += n[1]*df_umom_du[1];
-                if (isDOFBoundary_w != 1)
-                  dflux_wmom_dw += n[1]*df_wmom_dw[1];
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_vmom_du += dmom_u_acc_u * n[0] * (bc_v - v);
+		    dflux_vmom_dv += ( dmom_u_acc_u * n[1] * (bc_v - v) - flowSpeedNormal) ;
+		    dflux_vmom_dw += dmom_u_acc_u * n[2] * (bc_v - v);
+		  }
+		else
+		  {
+                    if (isDOFBoundary_u != 1)
+                      dflux_umom_du += n[1]*df_umom_du[1];
+                    if (isDOFBoundary_w != 1)
+                      dflux_wmom_dw += n[1]*df_wmom_dw[1];
+                  }
               }
           }
         if (isDOFBoundary_w != 1)
@@ -1669,6 +1754,15 @@ namespace proteus
                 dflux_wmom_du += n[2]*df_wmom_du[2];
                 dflux_wmom_dv += n[2]*df_wmom_dv[2];
                 dflux_wmom_dw += n[2]*df_wmom_dw[2];
+              }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_vmom_du += dmom_u_acc_u * n[0] * (0.0 - v);
+		    dflux_vmom_dv += dmom_u_acc_u * n[1] * (0.0 - v);
+		    dflux_vmom_dw += ( dmom_u_acc_u * n[2] * (0.0 - v) - flowSpeedNormal) ;
+		  }
               }
           }
         else
@@ -1691,10 +1785,19 @@ namespace proteus
               }
             else
               {
-                if (isDOFBoundary_u != 1)
-                  dflux_umom_du += n[2]*df_umom_du[2];
-                if (isDOFBoundary_v != 1)
-                  dflux_vmom_dv += n[2]*df_vmom_dv[2];
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_vmom_du += dmom_u_acc_u * n[0] * (0.0 - v);
+		    dflux_vmom_dv += dmom_u_acc_u * n[1] * (0.0 - v);
+		    dflux_vmom_dw += ( dmom_u_acc_u * n[2] * (0.0 - v) - flowSpeedNormal) ;
+		  }
+                else
+                  {
+                    if (isDOFBoundary_u != 1)
+                      dflux_umom_du += n[2]*df_umom_du[2];
+                    if (isDOFBoundary_v != 1)
+                      dflux_vmom_dv += n[2]*df_vmom_dv[2];
+                  }
               }
           }
         if (isDOFBoundary_p == 1)
@@ -5145,6 +5248,9 @@ namespace proteus
                                                           dmom_u_ham_grad_p_ext[0],//=1/rho
                                                           normal,
                                                           bc_p_ext,
+                                                          bc_u_ext,
+                                                          bc_v_ext,
+                                                          bc_w_ext,
                                                           bc_mass_adv_ext,
                                                           bc_mom_u_adv_ext,
                                                           bc_mom_v_adv_ext,
@@ -5154,6 +5260,10 @@ namespace proteus
                                                           ebqe_bc_flux_mom_v_adv_ext[ebNE_kb],
                                                           ebqe_bc_flux_mom_w_adv_ext[ebNE_kb],
                                                           p_ext,
+                                                          u_ext,
+                                                          v_ext,
+                                                          w_ext,
+                                                          dmom_u_acc_u_ext,
                                                           mass_adv_ext,
                                                           mom_u_adv_ext,
                                                           mom_v_adv_ext,

--- a/proteus/mprans/RANS2P2D.h
+++ b/proteus/mprans/RANS2P2D.h
@@ -1168,6 +1168,13 @@ namespace proteus
                 flux_umom += n[0]*f_umom[0];
                 flux_vmom += n[0]*f_vmom[0];
               }
+            else
+              {
+                if (NONCONSERVATIVE_FORM > 0.0)
+                  {
+                    flux_umom+=(0.0-u)*flowSpeedNormal;
+                  }
+              }
           }
         else
           {
@@ -1199,6 +1206,13 @@ namespace proteus
               {
                 flux_umom+=n[1]*f_umom[1];
                 flux_vmom+=n[1]*f_vmom[1];
+              }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    flux_vmom+=(0.0-v)*flowSpeedNormal;
+		  }
               }
           }
         else
@@ -1344,6 +1358,14 @@ namespace proteus
                 dflux_vmom_du += n[0]*df_vmom_du[0];
                 dflux_vmom_dv += n[0]*df_vmom_dv[0];
               }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_umom_du+=(  dmom_u_acc_u*n[0]*(0.0 - u) - flowSpeedNormal ) ;
+		    dflux_umom_dv+= dmom_u_acc_u * (0.0 - u) * n[1];
+		  }
+              }
           }
         else
           {
@@ -1381,6 +1403,14 @@ namespace proteus
                 
                 dflux_vmom_du += n[1]*df_vmom_du[1];
                 dflux_vmom_dv += n[1]*df_vmom_dv[1];
+              }
+            else
+              {
+		if (NONCONSERVATIVE_FORM > 0.0)
+		  {
+		    dflux_vmom_du += dmom_u_acc_u * n[0] * (0.0 - v);
+		    dflux_vmom_dv += ( dmom_u_acc_u * n[1] * (0.0 - v) - flowSpeedNormal) ;
+		  }
               }
           }
         else

--- a/proteus/mprans/RANS2P2D.h
+++ b/proteus/mprans/RANS2P2D.h
@@ -1232,8 +1232,8 @@ namespace proteus
 		  }
 		else
 		  {
-                flux_umom+=n[1]*bc_f_umom[1];
-                flux_vmom+=n[1]*bc_f_vmom[1];
+                    flux_umom+=n[1]*bc_f_umom[1];
+                    flux_vmom+=n[1]*bc_f_vmom[1];
 		  }
               }
           }

--- a/proteus/mprans/RANS3PF.h
+++ b/proteus/mprans/RANS3PF.h
@@ -1472,6 +1472,10 @@ namespace proteus
         if (isDOFBoundary_u != 1)
           {
             flux_mass += n[0]*f_mass[0];
+            if (flowSpeedNormal < 0.0)
+              {
+                flux_umom+=flowSpeedNormal*(0.0 - u);
+              }
           }
         else
           {
@@ -1485,6 +1489,10 @@ namespace proteus
         if (isDOFBoundary_v != 1)
           {
             flux_mass+=n[1]*f_mass[1];
+            if (flowSpeedNormal < 0.0)
+              {
+                flux_vmom+=flowSpeedNormal*(0.0 - v);
+              }
           }
         else
           {
@@ -1498,6 +1506,10 @@ namespace proteus
         if (isDOFBoundary_w != 1)
           {
             flux_mass+=n[2]*f_mass[2];
+            if (flowSpeedNormal < 0.0)
+              {
+                flux_wmom+=flowSpeedNormal*(0.0 - w);
+              }
           }
         else
           {
@@ -1624,6 +1636,8 @@ namespace proteus
         if (isDOFBoundary_u != 1)
           {
             dflux_mass_du += n[0]*df_mass_du[0];
+            if (flowSpeedNormal < 0.0)
+              dflux_umom_du -= flowSpeedNormal;
           }
         else
           {
@@ -1634,6 +1648,8 @@ namespace proteus
         if (isDOFBoundary_v != 1)
           {
             dflux_mass_dv += n[1]*df_mass_dv[1];
+            if (flowSpeedNormal < 0.0)
+              dflux_vmom_dv -= flowSpeedNormal;
           }
         else
           {
@@ -1644,6 +1660,8 @@ namespace proteus
         if (isDOFBoundary_w != 1)
           {
             dflux_mass_dw+=n[2]*df_mass_dw[2];
+            if (flowSpeedNormal < 0.0)
+              dflux_wmom_dw -= flowSpeedNormal;
           }
         else
           {

--- a/proteus/mprans/RANS3PF2D.h
+++ b/proteus/mprans/RANS3PF2D.h
@@ -1552,6 +1552,10 @@ namespace proteus
         if (isDOFBoundary_u != 1)
           {
             flux_mass += n[0]*f_mass[0];
+            if (flowSpeedNormal < 0.0)
+              {
+                flux_umom+=flowSpeedNormal*(0.0 - u);
+              }
           }
         else
           {
@@ -1565,6 +1569,10 @@ namespace proteus
         if (isDOFBoundary_v != 1)
           {
             flux_mass+=n[1]*f_mass[1];
+            if (flowSpeedNormal < 0.0)
+              {
+                flux_vmom+=flowSpeedNormal*(0.0 - v);
+              }
           }
         else
           {
@@ -1713,6 +1721,8 @@ namespace proteus
         if (isDOFBoundary_u != 1)
           {
             dflux_mass_du += n[0]*df_mass_du[0];
+            if (flowSpeedNormal < 0.0)
+              dflux_umom_du -= flowSpeedNormal;
           }
         else
           {
@@ -1723,6 +1733,8 @@ namespace proteus
         if (isDOFBoundary_v != 1)
           {
             dflux_mass_dv += n[1]*df_mass_dv[1];
+            if (flowSpeedNormal < 0.0)
+              dflux_vmom_dv -= flowSpeedNormal;
           }
         else
           {


### PR DESCRIPTION
When we using the non-conservative form of the NSE momentum equations we need to use an upwind penalty flux in the case of flow entering the domain. We already to this in RANS3P. This PR adds them for RANS2P. This term effectively stabilizes cases where we have flow into the domain due to hydrostatic pressure Dirichlet conditions with outflow conditions, or in some cases with velocity Dirichlet conditions for inflow.