### PR TITLE
switched back to default optimization options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 - git submodule update --recursive --remote  
 - make profile
 - make distclean
-- FC=gfortran CC=mpicc CXX=mpicxx make install N=2
+- PROTEUS_OPT="-O0 -UNDEBUG" FC=gfortran CC=mpicc CXX=mpicxx make install N=2
 - export PATH=$PWD/linux2/bin:$PATH
 - export LD_LIBRARY_PATH=$PWD/linux2/lib:$LD_LIBRARY_PATH
 - export SSL_CERT_DIR=/etc/ssl/certs

--- a/proteus/config/default.py
+++ b/proteus/config/default.py
@@ -10,7 +10,7 @@ if not prefix:
 
 PROTEUS_OPT = os.getenv('PROTEUS_OPT')
 if not PROTEUS_OPT:
-    PROTEUS_OPT=['-O0','-UNDEBUG']
+    PROTEUS_OPT=['-O3','-DNDEBUG']
 
 PROTEUS_INCLUDE_DIR = pjoin(prefix, 'include')
 PROTEUS_LIB_DIR = pjoin(prefix, 'lib')

--- a/proteus/config/default.py
+++ b/proteus/config/default.py
@@ -8,7 +8,7 @@ prefix = os.getenv('PROTEUS_PREFIX')
 if not prefix:
     prefix = sys.exec_prefix
 
-PROTEUS_OPT = os.getenv('PROTEUS_OPT')
+PROTEUS_OPT = os.getenv('PROTEUS_OPT').split()
 if not PROTEUS_OPT:
     PROTEUS_OPT=['-O3','-DNDEBUG']
 

--- a/proteus/config/default.py
+++ b/proteus/config/default.py
@@ -8,10 +8,12 @@ prefix = os.getenv('PROTEUS_PREFIX')
 if not prefix:
     prefix = sys.exec_prefix
 
-PROTEUS_OPT = os.getenv('PROTEUS_OPT').split()
+PROTEUS_OPT = os.getenv('PROTEUS_OPT')
 if not PROTEUS_OPT:
     PROTEUS_OPT=['-O3','-DNDEBUG']
-
+else:
+    PROTEUS_OPT=PROTEUS_OPT.split()
+    
 PROTEUS_INCLUDE_DIR = pjoin(prefix, 'include')
 PROTEUS_LIB_DIR = pjoin(prefix, 'lib')
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ cv["CFLAGS"] = cv["CFLAGS"].replace("-Wstrict-prototypes","")
 
 PROTEUS_PETSC_EXTRA_LINK_ARGS = getattr(config, 'PROTEUS_PETSC_EXTRA_LINK_ARGS', [])
 PROTEUS_PETSC_EXTRA_COMPILE_ARGS = getattr(config, 'PROTEUS_PETSC_EXTRA_COMPILE_ARGS', [])
-PROTEUS_OPT=['-O0','-UNDEBUG']
 PROTEUS_CHRONO_CXX_FLAGS = getattr(config, 'PROTEUS_CHRONO_CXX_FLAGS', [])
 
 proteus_install_path = os.path.join(sysconfig.get_python_lib(), 'proteus')


### PR DESCRIPTION
- `PROTEUS_OPT="-O3 -DNDEBUG"` is again the default
- `export PROTEUS_OPT="-O0 -UNDEBUG"` to get fast compile times but slow proteus
- travis will use the fast build 