### PR TITLE
fix return type in forward declaration

### DIFF
--- a/proteus/fenton/Inout.cpp
+++ b/proteus/fenton/Inout.cpp
@@ -141,7 +141,8 @@ void Output(void)
 {
 int 		i, I;
 double 	X, eta, y;
-double	Surface(double), Point(double, double);
+ double	Surface(double);
+ void Point(double, double);
 
 fprintf(monitor,"\n\n# Solution summary:\n\n");
 Title_block(monitor);


### PR DESCRIPTION
I had this issue compiling on a new mac. It looks like the forward declaration doesn't match the definition. @adimako @tridelat 