### PR TITLE
reverse change to handling of ghost boundaries

### DIFF
--- a/proteus/mprans/RANS2P.h
+++ b/proteus/mprans/RANS2P.h
@@ -3572,7 +3572,7 @@ namespace proteus
                 //
                 //update residuals
                 //
-                if(boundaryFlags[ebN] > 0)
+                if(true)//boundaryFlags[ebN] > 0)
                   { //ignore flux contributions on interpart boundaries
                     for (int i=0;i<nDOF_test_element;i++)
                       {
@@ -5304,7 +5304,7 @@ namespace proteus
                 //
                 ck.calculateGScale(G,normal,h_penalty);
                 penalty = useMetrics*C_b/h_penalty + (1.0-useMetrics)*ebqe_penalty_ext[ebNE_kb];
-                if (boundaryFlags[ebN] > 0)
+                if (true)//boundaryFlags[ebN] > 0)
                   {
                     for (int j=0;j<nDOF_trial_element;j++)
                       {

--- a/proteus/mprans/RANS2P2D.h
+++ b/proteus/mprans/RANS2P2D.h
@@ -3010,7 +3010,7 @@ namespace proteus
                 //
                 //update residuals
                 //
-                if(boundaryFlags[ebN] > 0)
+                if(true)//boundaryFlags[ebN] > 0)
                   { //if boundary flag positive, then include flux contributions on interpart boundaries
                     for (int i=0;i<nDOF_test_element;i++)
                       {
@@ -4536,7 +4536,7 @@ namespace proteus
                 //
                 ck.calculateGScale(G,normal,h_penalty);
                 penalty = useMetrics*C_b/h_penalty + (1.0-useMetrics)*ebqe_penalty_ext[ebNE_kb];
-                if(boundaryFlags[ebN] > 0)
+                if(true)//boundaryFlags[ebN] > 0)
                   { //if boundary flag positive, then include flux contributions on interpart boundaries
                     for (int j=0;j<nDOF_trial_element;j++)
                       {


### PR DESCRIPTION
@zhang-alvin it looks like something isn't right about how you are turning off the internal boundaries. That's why you're having trouble with convergence in parallel for element-based partitioning. I suspect something is being used uninitialized. @wacyyang this may be affection your SBM results in parallel--not sure. I don't think this should be affecting anyone using nodal partitionings, but this sort of bug may not express itself in an obvious/reliable way. For now I think we need to just roll this back and set boundaries carefully in the input files. 