### PR TITLE
fixed missing initialization of basis gradients

### DIFF
--- a/proteus/mprans/Pres.h
+++ b/proteus/mprans/Pres.h
@@ -190,6 +190,10 @@ namespace proteus
           for (int j=0;j<nDOF_trial_element;j++)
             {
               u_test_dV[j] = u_test_ref[k*nDOF_trial_element+j]*dV;
+              for (int I=0;I<nSpace;I++)
+                {
+                  u_grad_test_dV[j*nSpace+I]   = u_grad_trial[j*nSpace+I]*dV;//cek warning won't work for Petrov-Galerkin
+                }
             }
           //
           //calculate pde coefficients at quadrature points
@@ -476,7 +480,6 @@ namespace proteus
             u_grad_trial[nDOF_trial_element*nSpace],
             dV,
             u_test_dV[nDOF_test_element],
-            u_grad_test_dV[nDOF_test_element*nSpace],
             x,y,z,
             G[nSpace*nSpace],G_dd_G,tr_G;
           //


### PR DESCRIPTION
This appears to be what was causing an intermittent problem with using `LevelModelType = Pres.LevelModel` (the optimized pressure calculation in RANS3P). 
/cc @manuel-quezada @wacyyang @adimako @Pedrohrw @arnsong  