### PR TITLE
removed hide_code jupyter extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ jupyter:
 	@echo "************************************"
 	@echo "Enabling jupyter notebook/lab/widgets"
 	source ${PROTEUS_PREFIX}/bin/proteus_env.sh
-	pip install configparser==3.5.0 ipyparallel==6.1.1 ipython==5.5.0 terminado==0.8.1 jupyter==1.0.0 jupyterlab==0.31.12 ipywidgets==7.1.2 ipyleaflet==0.7.1 jupyter_dashboards==0.7.0 pythreejs==0.4.1 rise==5.2.0 cesiumpy==0.3.3 bqplot==0.10.5 hide_code==0.5.0 ipympl==0.1.0 sympy==1.1.1 transforms3d==0.3.1 ipymesh
+	pip install configparser==3.5.0 ipyparallel==6.1.1 ipython==5.5.0 terminado==0.8.1 jupyter==1.0.0 jupyterlab==0.31.12 ipywidgets==7.1.2 ipyleaflet==0.7.1 jupyter_dashboards==0.7.0 pythreejs==0.4.1 rise==5.2.0 cesiumpy==0.3.3 bqplot==0.10.5 ipympl==0.1.0 sympy==1.1.1 transforms3d==0.3.1 ipymesh
 	ipcluster nbextension enable --user
 	jupyter serverextension enable --py jupyterlab --sys-prefix
 	jupyter nbextension enable --py --sys-prefix widgetsnbextension
@@ -340,8 +340,6 @@ jupyter:
 	jupyter nbextension enable --py --sys-prefix ipympl
 	jupyter nbextension enable --py --sys-prefix ipymesh
 	jupyter nbextension enable --py --sys-prefix ipyleaflet
-	jupyter nbextension install --py --sys-prefix hide_code
-	jupyter nbextension enable --py --sys-prefix hide_code
 	jupyter nbextension install --py --sys-prefix rise
 	jupyter nbextension enable --py --sys-prefix rise
 	jupyter dashboards quick-setup --sys-prefix


### PR DESCRIPTION
The hide_code extension is no longer maintained and was breaking with recent updates to other parts of the statck, so I removed it. You need to do a `make distclean` for this to take effect (e.g. `make distclean; make N=4 PROTEUS_OPT="-g -UNDEBUG" develop; make jupyter`

/cc @alistairbntl and @bchambers28