### PR TITLE
Arnsong/fix sbm

### DIFF
--- a/proteus/mprans/RANS3PF.py
+++ b/proteus/mprans/RANS3PF.py
@@ -226,6 +226,7 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
                  ball_radius=None,
                  ball_velocity=None,
                  ball_angular_velocity=None,
+                 particles=None
                  ):
         self.MULTIPLY_EXTERNAL_FORCE_BY_DENSITY=MULTIPLY_EXTERNAL_FORCE_BY_DENSITY
         self.CORRECT_VELOCITY = CORRECT_VELOCITY
@@ -352,6 +353,12 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
         else:
             self.ball_angular_velocity = ball_angular_velocity
         #
+
+        self.particles = particles
+
+        if self.particles:
+            self.nParticles = self.particles.size();
+        
         mass = {}
         advection = {}
         diffusion = {}
@@ -480,49 +487,22 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
         # otherwise the sdf are calculated based on the input sdf list for each body
         if self.use_ball_as_particle==1:
             pass
-        elif self.granular_sdf_Calc is not None:
-            temp_1 = np.zeros(self.model.q[('u', 0)].shape, 'd')
-            temp_2 = np.zeros(self.model.q[('u', 0)].shape, 'd')
-            temp_3 = np.zeros(self.model.q[('u', 0)].shape, 'd')
-            for i in range(self.nParticles):
-                logEvent("Attaching particle i={0}".format(i))
-                for eN in range(self.model.q['x'].shape[0]):
-                    for k in range(self.model.q['x'].shape[1]):
-                        self.particle_signed_distances[i, eN, k], self.particle_signed_distance_normals[i,
-                                                                                                        eN, k] = self.granular_sdf_Calc(self.model.q['x'][eN, k], i)
-                        self.particle_velocities[i, eN, k] = self.granular_vel_Calc(self.model.q['x'][eN, k], i)
-                # This is important to write the a field for the sdf in the domain which distinguishes solid particles
-                temp_1 = np.minimum(abs(self.particle_signed_distances[i]), abs(self.phisField))
-                temp_2 = np.minimum(self.particle_signed_distances[i], temp_1)
-                temp_3 = np.minimum(temp_2, self.phisField)
-                self.phisField = temp_3
-                self.model.q[('phis')] = temp_3
-                for ebN in range(self.model.ebq_global['x'].shape[0]):
-                    for kb in range(self.model.ebq_global['x'].shape[1]):
-                        sdf,sdNormals = self.granular_sdf_Calc(self.model.ebq_global['x'][ebN,kb],i)
-                        if ( abs(sdf) < abs(self.ebq_global_phi_s[ebN,kb]) ):
-                            self.ebq_global_phi_s[ebN,kb]=sdf
-                            self.ebq_global_grad_phi_s[ebN,kb,:]=sdNormals
         else:
-            corresponding_point_on_boundary = np.zeros((3,),'d')
-            for i, sdf, vel in zip(range(self.nParticles),
-                                   self.particle_sdfList, self.particle_velocityList):
-                for eN in range(self.model.q['x'].shape[0]):
-                    for k in range(self.model.q['x'].shape[1]):
-                        self.particle_signed_distances[i, eN, k], self.particle_signed_distance_normals[i, eN, k] = sdf(0.0, self.model.q['x'][eN, k])
-                        self.particle_velocities[i, eN, k] = vel(0.0, self.model.q['x'][eN, k])
-                self.model.q[('phis', i)] = self.particle_signed_distances[i]
-                self.model.q[('phis_vel', i)] = self.particle_velocities[i]
-                for ebN in range(self.model.ebq_global['x'].shape[0]):
-                    for kb in range(self.model.ebq_global['x'].shape[1]):
-                        sdf_ebN_kb,sdNormals = sdf(0.0, self.model.ebq_global['x'][ebN,kb],)
-                        if ( abs(sdf_ebN_kb) < abs(self.ebq_global_phi_s[ebN,kb]) ):
-                            self.ebq_global_phi_s[ebN,kb]=sdf_ebN_kb
-                            self.ebq_global_grad_phi_s[ebN,kb,:]=sdNormals
-                            for j in range(len(sdNormals)):
-                                corresponding_point_on_boundary[j] = self.model.ebq_global['x'][ebN,kb][j] - sdf_ebN_kb*sdNormals[j]
-                            self.ebq_particle_velocity_s[ebN,kb,:]=vel(0.0,corresponding_point_on_boundary)
+            # Might need to add particle centroid updates in updateSDF function
+            self.particles.updateSDF(self.mesh.nodeArray,
+                                     self.model.q['x'],
+                                     self.model.ebq_global['x'],
+                                     self.phi_s,
+                                     self.particle_signed_distances,
+                                     self.particle_signed_distance_normals,
+                                     self.particle_velocities,
+                                     self.ebq_global_phi_s,
+                                     self.ebq_global_grad_phi_s,
+                                     self.ebq_particle_velocity_s)
 
+            for i in range(self.particles.size()):
+                self.particle_centroids[i,:] = self.particles[i].x()
+            
         if self.PRESSURE_model is not None:
             self.model.pressureModel = modelList[self.PRESSURE_model]
             self.model.q_p_fluid = modelList[self.PRESSURE_model].q[('u', 0)]
@@ -667,9 +647,12 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
         ), "epsFact_solid  array is not large  enough for the materials  in this mesh; length must be greater  than largest  material type ID"
 
     def initializeMesh(self, mesh):
+
+        
         self.phi_s = numpy.ones(mesh.nodeArray.shape[0], 'd')*1e10
 
         logEvent("updating {0} particles...".format(self.nParticles))
+        
         for i in range(self.nParticles):
             if self.use_ball_as_particle == 1:
                 sdf = lambda x: (np.linalg.norm(x-self.ball_center[i]),0)
@@ -677,12 +660,12 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
                 if self.granular_sdf_Calc is not None:
                     sdf = lambda x: self.granular_sdf_Calc(x,i)
                 else:
-                    sdf = lambda x: self.particle_sdfList[i](0.0, x)
+                    sdf = lambda x: self.particles[i].sdf(x)
 
             for j in range(mesh.nodeArray.shape[0]):
-                sdf_at_node, _ = sdf(mesh.nodeArray[j, :])
+                sdf_at_node = sdf(mesh.nodeArray[j,:])
                 if (abs(sdf_at_node) < abs(self.phi_s[j])):
-                            self.phi_s[j] = sdf_at_node
+                    self.phi_s[j] = sdf_at_node
 
         # cek we eventually need to use the local element diameter
         self.eps_density = self.epsFact_density * mesh.h
@@ -1061,64 +1044,28 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
 
         logEvent("updating {0} particles...".format(self.nParticles))
         if self.use_ball_as_particle == 0:
-            self.phi_s[:] = 1e10
-            self.phisField = np.ones(self.model.q[('u', 0)].shape, 'd') * 1e10
-            for i in range(self.nParticles):
-                if self.granular_sdf_Calc is not None:
-                    vel = lambda x: self.granular_vel_Calc(x, i)
-                    sdf = lambda x: self.granular_sdf_Calc(x, i)
-                else:
-                    vel = lambda x: self.particle_velocityList[i](t, x)
-                    sdf = lambda x: self.particle_sdfList[i](t, x)
-                    
-                for j in range(self.mesh.nodeArray.shape[0]):
-                    vel_at_node = vel(self.mesh.nodeArray[j, :])
-                    sdf_at_node, sdNormals = sdf(self.mesh.nodeArray[j, :])
-                    if (abs(sdf_at_node) < abs(self.phi_s[j])):
-                        self.phi_s[j] = sdf_at_node
-                for eN in range(self.model.q['x'].shape[0]):
-                    for k in range(self.model.q['x'].shape[1]):
-                        self.particle_signed_distances[i, eN, k], self.particle_signed_distance_normals[i, eN, k] = sdf(self.model.q['x'][eN, k])
-                        self.particle_velocities[i, eN, k] = vel(self.model.q['x'][eN, k])
-                        if (abs(self.particle_signed_distances[i, eN, k]) < abs(self.phisField[eN, k])):
-                            self.phisField[eN, k] = self.particle_signed_distances[i, eN, k]
-                corresponding_point_on_boundary = numpy.zeros((3,),'d')
-                for ebN in range(self.model.ebq_global['x'].shape[0]):
-                    for kb in range(self.model.ebq_global['x'].shape[1]):
-                        sdf_at_quad_pt,sdNormals = sdf(self.model.ebq_global['x'][ebN,kb])
-                        if ( abs(sdf_at_quad_pt) < abs(self.ebq_global_phi_s[ebN,kb]) ):
-                            self.ebq_global_phi_s[ebN,kb]=sdf_at_quad_pt
-                            self.ebq_global_grad_phi_s[ebN,kb,:]=sdNormals
-                            for j in range(len(sdNormals)):
-                                corresponding_point_on_boundary[j] = self.model.ebq_global['x'][ebN,kb][j] - sdf_at_quad_pt*sdNormals[j]
-                            self.ebq_particle_velocity_s[ebN,kb,:]=vel(0.0,corresponding_point_on_boundary)
-            self.model.q[('phis')] = self.phisField
 
-            #Update velocity inside the particle
-            for ci_g_dof,ci_fg_dof in self.model.dirichletConditions[0].global2freeGlobal.iteritems():
-                if isinstance(self.model.u[0].femSpace,C0_AffineLinearOnSimplexWithNodalBasis):
-                    xyz = self.model.mesh.nodeArray[ci_g_dof,:]
-                elif isinstance(self.model.u[0].femSpace,C0_AffineQuadraticOnSimplexWithNodalBasis):
-                    xyz = self.model.u[0].femSpace.dofMap.lagrangeNodesArray[ci_g_dof,:]
-                else:
-                    assert False,"Use P1 or P2 for velocity"
-                distance_to_solid = 1e10
-                for i in range(self.nParticles):
-                    if self.granular_sdf_Calc is not None:
-                        vel = lambda x: self.granular_vel_Calc(x, i)
-                        sdf = lambda x: self.granular_sdf_Calc(x, i)
-                    else:
-                        vel = lambda x: self.particle_velocityList[i](t, x)
-                        sdf = lambda x: self.particle_sdfList[i](t, x)
-                    distance_to_i_particle,_ = sdf(xyz)
-                    if distance_to_solid > distance_to_i_particle:
-                        vel_at_xyz = vel(xyz)
-                        distance_to_solid = distance_to_i_particle
-                for ci in range(self.nc):#since nc=nd
-                    dof = self.model.offset[ci] + self.model.stride[ci]*ci_fg_dof
-                    if self.model.isActiveDOF[dof] < 0.5:
-                        self.model.u[ci].dof[ci_g_dof] = vel_at_xyz[ci]
+            self.particles.moveParticles(self.particle_netForces, 
+                                         self.particle_netMoments, 
+                                         self.model.dt_last, 
+                                         t,
+                                         1000,
+                                         "particles_out")
+            
+            self.particles.updateSDF(self.mesh.nodeArray,
+                                     self.model.q['x'],
+                                     self.model.ebq_global['x'],
+                                     self.phi_s,
+                                     self.particle_signed_distances,
+                                     self.particle_signed_distance_normals,
+                                     self.particle_velocities,
+                                     self.ebq_global_phi_s,
+                                     self.ebq_global_grad_phi_s,
+                                     self.ebq_particle_velocity_s)
 
+            for i in range(self.particles.size()):
+                self.particle_centroids[i,:] = self.particles[i].x()
+            
         if self.model.comm.isMaster():
             self.wettedAreaHistory.write("%21.16e\n" % (self.wettedAreas[-1],))
             self.forceHistory_p.write("%21.16e %21.16e %21.16e\n" % tuple(self.netForces_p[-1, :]))


### PR DESCRIPTION
### Introduction
This is an attempt to standardize the way that Proteus couples to particle codes in a manner that leaves responsibility in the appropriate places, i.e., the particle code calculates and hands off information such as the signed distance function or the particle positions and Proteus only worries about calculating the fluid solution with this information.  This is a work in progress, so any suggestions are welcome. 

### Implementation
This API contains only 3 functions to facilitate information handoff between Proteus and the particle solver. We access these function through the particle solver object which is passed to the `RANS3PF.Coefficients` object.  In this document, we will refer to the particle solver object as `particles`
- `particles[i].x()` -- Return the centroid position of particle **i**
- `particles[i].sdf(position)` -- This calculates the sdf for a particle **i** at **position**.
- `particles.updateSDF(...)` -- Vectorized sdf calculation for at Proteus nodes and integration points

The first two functions should be straightforward to implement in the particle solver. The vectorized `updateSDF` function is a little more involved.  In theory, another particle code should be able to take the code that we use to expose our c++ backend to python and merely replace our headers with theirs and link to their libraries.  Theoretically... There is a little more work to be done on the C++ side to make this a reality, but very doable. 