### PR TITLE
fix option -H hotstart dataDir issue

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@
 - Copyright 2018 John Fenton johndfenton@gmail.com
 - Copyright 2018 Manuel Quezada de Luna manuel.quezada.dl@gmail.com
 - Copyright 2018 Yong Yang wacyyang@gmail.com
+- Copyright 2019 Greg Burgreen greg.burgreen@msstate.edu
 
 **Note for U.S. Federal Employees**
 

--- a/proteus/Archiver.py
+++ b/proteus/Archiver.py
@@ -98,7 +98,7 @@ class AR_base(object):
                                   "a")
             if self.has_h5py and not useTextArchive:
                 self.hdfFilename=filename+".h5"
-                self.hdfFile=h5py.File(self.hdfFilename,
+                self.hdfFile=h5py.File(os.path.join(self.dataDir,self.hdfFilename),
                                        "a",
                                        driver="mpio",
                                        comm = comm_world)


### PR DESCRIPTION
One line change is not tested. I am waiting for all Python3 conversions before updating the MSU build process of the latest Proteus version. 