### PR TITLE
PR to measure speed of the code

### DIFF
--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -1770,7 +1770,7 @@ class NS_base(object):  # (HasTraits):
                     NDOFs=0
                     for i,mod in enumerate(self.modelList):
                         if (i in self.so.modelSpinUpList) == False: #To remove spin up models
-                            NDOFs += len(mod.uList[0])
+                            NDOFs += mod.par_uList[0].size
                     #
                     file = open("speed_measurement.txt","w")
                     file.write("Num of time steps: " + str(numTimeSteps) + "\n")
@@ -1778,7 +1778,6 @@ class NS_base(object):  # (HasTraits):
                     file.write("Num of processors: " + str(Nproc) + "\n")
                     file.write("Total num of DOFs: " + str(NDOFs) + "\n")
                     file.write("Num of DOFs per processor: " + str(NDOFs/Nproc) + "\n")
-                    file.write("Time per time step, per processor: " + str((end-start)/numTimeSteps*Nproc) + "\n")
                     file.write("Time per time step, per DOF, per processor: " + str((end-start)/numTimeSteps*Nproc/NDOFs) + "\n")
                     file.close()
                     measureSpeed = False
@@ -1789,7 +1788,7 @@ class NS_base(object):  # (HasTraits):
                 NDOFs=0
                 for i,mod in enumerate(self.modelList):
                     if (i in self.so.modelSpinUpList) == False:
-                        NDOFs += len(mod.uList[0])
+                        NDOFs += mod.par_uList[0].size
                 #
                 file = open("speed_measurement.txt","w")
                 file.write("Num of time steps: " + str(numTimeSteps) + "\n")
@@ -1797,7 +1796,6 @@ class NS_base(object):  # (HasTraits):
                 file.write("Num of processors: " + str(Nproc) + "\n")
                 file.write("Total num of DOFs: " + str(NDOFs) + "\n")
                 file.write("Num of DOFs per processor: " + str(NDOFs/Nproc) + "\n")
-                file.write("Time per time step, per processor: " + str((end-start)/numTimeSteps*Nproc) + "\n")
                 file.write("Time per time step, per DOF, per processor: " + str((end-start)/numTimeSteps*Nproc/NDOFs) + "\n")
                 file.close()
                 measureSpeed = False

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -1770,7 +1770,7 @@ class NS_base(object):  # (HasTraits):
                     NDOFs=0
                     for i,mod in enumerate(self.modelList):
                         if (i in self.so.modelSpinUpList) == False: #To remove spin up models
-                            NDOFs += mod.par_uList[0].size
+                            NDOFs += mod.par_uList[0].size if mod.par_uList[0] is not None else len(mod.uList[0])
                     #
                     file = open("speed_measurement.txt","w")
                     file.write("Num of time steps: " + str(numTimeSteps) + "\n")
@@ -1788,7 +1788,7 @@ class NS_base(object):  # (HasTraits):
                 NDOFs=0
                 for i,mod in enumerate(self.modelList):
                     if (i in self.so.modelSpinUpList) == False:
-                        NDOFs += mod.par_uList[0].size
+                        NDOFs += mod.par_uList[0].size if mod.par_uList[0] is not None else len(mod.uList[0])
                 #
                 file = open("speed_measurement.txt","w")
                 file.write("Num of time steps: " + str(numTimeSteps) + "\n")

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -1772,14 +1772,23 @@ class NS_base(object):  # (HasTraits):
                         if (i in self.so.modelSpinUpList) == False: #To remove spin up models
                             NDOFs += mod.par_uList[0].size if mod.par_uList[0] is not None else len(mod.uList[0])
                     #
-                    file = open("speed_measurement.txt","w")
-                    file.write("Num of time steps: " + str(numTimeSteps) + "\n")
-                    file.write("Total time: " + str(end-start) + "\n")
-                    file.write("Num of processors: " + str(Nproc) + "\n")
-                    file.write("Total num of DOFs: " + str(NDOFs) + "\n")
-                    file.write("Num of DOFs per processor: " + str(NDOFs/Nproc) + "\n")
-                    file.write("Time per time step, per DOF, per processor: " + str((end-start)/numTimeSteps*Nproc/NDOFs) + "\n")
-                    file.close()
+                    with open ("speed_measurement.txt","w") as file:
+                        # write file
+                        file.write("""Num of time steps: {nts:d} \n""".format(nts=numTimeSteps))
+                        file.write("""Total time: {t:f} \n""".format(t=(end-start)))
+                        file.write("""Num of processors: {Nproc:d} \n""".format(Nproc=Nproc))
+                        file.write("""Total num of DOFs: {NDOFs:d} \n""".format(NDOFs=NDOFs))
+                        file.write("""Num of DOFs per processor: {x:d} \n""".format(x=int(NDOFs/Nproc)))
+                        file.write("""Time per time step, per DOF, per processor: {x:.4E} \n""".format(x=(end-start)/numTimeSteps*Nproc/NDOFs))
+                        # log info
+                        logEvent("""*** Measurement for the speed of the code  ***""", level=4)
+                        logEvent("""    Num of time steps: {nts:d}""".format(nts=numTimeSteps),level=4)
+                        logEvent("""    Total time: {t:f}""".format(t=(end-start)),level=4)
+                        logEvent("""    Num of processors: {Nproc:d}""".format(Nproc=Nproc),level=4)
+                        logEvent("""    Total num of DOFs: {NDOFs:d}""".format(NDOFs=NDOFs),level=4)
+                        logEvent("""    Num of DOFs per processor: {x:d}""".format(x=int(NDOFs/Nproc)),level=4)
+                        logEvent("""    Time per time step, per DOF, per processor: {x:.4E}""".format(x=(end-start)/numTimeSteps*Nproc/NDOFs),level=4)
+                    #
                     measureSpeed = False
                 #
             if measureSpeed and startToMeasureSpeed and self.comm.isMaster():
@@ -1790,14 +1799,23 @@ class NS_base(object):  # (HasTraits):
                     if (i in self.so.modelSpinUpList) == False:
                         NDOFs += mod.par_uList[0].size if mod.par_uList[0] is not None else len(mod.uList[0])
                 #
-                file = open("speed_measurement.txt","w")
-                file.write("Num of time steps: " + str(numTimeSteps) + "\n")
-                file.write("Total time: " + str(end-start) + "\n")
-                file.write("Num of processors: " + str(Nproc) + "\n")
-                file.write("Total num of DOFs: " + str(NDOFs) + "\n")
-                file.write("Num of DOFs per processor: " + str(NDOFs/Nproc) + "\n")
-                file.write("Time per time step, per DOF, per processor: " + str((end-start)/numTimeSteps*Nproc/NDOFs) + "\n")
-                file.close()
+                with open ("speed_measurement.txt","w") as file:
+                    # write file
+                    file.write("""Num of time steps: {nts:d} \n""".format(nts=numTimeSteps))
+                    file.write("""Total time: {t:f} \n""".format(t=(end-start)))
+                    file.write("""Num of processors: {Nproc:d} \n""".format(Nproc=Nproc))
+                    file.write("""Total num of DOFs: {NDOFs:d} \n""".format(NDOFs=NDOFs))
+                    file.write("""Num of DOFs per processor: {x:d} \n""".format(x=int(NDOFs/Nproc)))
+                    file.write("""Time per time step, per DOF, per processor: {x:.4E} \n""".format(x=(end-start)/numTimeSteps*Nproc/NDOFs))
+                    # log info
+                    logEvent("""*** Measurement for the speed of the code  ***""", level=4)
+                    logEvent("""    Num of time steps: {nts:d}""".format(nts=numTimeSteps),level=4)
+                    logEvent("""    Total time: {t:f}""".format(t=(end-start)),level=4)
+                    logEvent("""    Num of processors: {Nproc:d}""".format(Nproc=Nproc),level=4)
+                    logEvent("""    Total num of DOFs: {NDOFs:d}""".format(NDOFs=NDOFs),level=4)
+                    logEvent("""    Num of DOFs per processor: {x:d}""".format(x=int(NDOFs/Nproc)),level=4)
+                    logEvent("""    Time per time step, per DOF, per processor: {x:.4E}""".format(x=(end-start)/numTimeSteps*Nproc/NDOFs),level=4)
+                #
                 measureSpeed = False
             #
             #end system step iterations


### PR DESCRIPTION
Small PR to measure the speed of the code. This is useful for checking how the code scales in HPCs and maybe to start getting a sense of what a good speed is and how our different methods and implementations perform. To activate this the user needs to add `measureSpeedOfCode=True` in the so file. 

The code starts measuring the speed after the first output and stops after 100 time steps or before the second output (whatever happens first). Then it writes a txt file with the number of time steps, number of processors and times. It also reports the time to solve 1 DOF for one time step multiplied by the number of processors; i.e., how much it took one processor to solve 1 DOF on one time step. If I recall correctly, based on Jean-Luc's standards back when I was in the PhD, 1E-5 was a good time. I did some experiments in 2D with the TwoPhaseFlow code using rans3p + clsvof and I got ~1.5E-5 using one processor. The time increased fast as I used more processors but I think that was (maybe) because of expected strong scaling issues. 
