### PR TITLE
Spatial Tools Compatibility with Element-based Partitioning

### DIFF
--- a/proteus/mprans/BoundaryConditions.py
+++ b/proteus/mprans/BoundaryConditions.py
@@ -145,7 +145,6 @@ class BC_RANS(BoundaryConditions.BC_Base):
         self.v_advective.setConstantBC(0.)
         self.w_advective.setConstantBC(0.)
         self.u_diffusive.setConstantBC(0.)
-        self.u_diffusive.setConstantBC(0.)
         self.v_diffusive.setConstantBC(0.)
         self.w_diffusive.setConstantBC(0.)
         self.us_diffusive.setConstantBC(0.)

--- a/proteus/mprans/BoundaryConditions.py
+++ b/proteus/mprans/BoundaryConditions.py
@@ -140,6 +140,11 @@ class BC_RANS(BoundaryConditions.BC_Base):
         self.BC_type = 'NonMaterial'
         self.vof_advective.setConstantBC(0.)
         self.vos_advective.setConstantBC(0.)
+        self.p_advective.setConstantBC(0.)
+        self.u_advective.setConstantBC(0.)
+        self.v_advective.setConstantBC(0.)
+        self.w_advective.setConstantBC(0.)
+        self.u_diffusive.setConstantBC(0.)
         self.u_diffusive.setConstantBC(0.)
         self.v_diffusive.setConstantBC(0.)
         self.w_diffusive.setConstantBC(0.)


### PR DESCRIPTION
There were some issues observed when running a 2D dambreak_Colagrossi case from air-water-vv using the SpatialTools-based setup and mesh partitioning by elements. 

The error was that on the interpart boundaries, the boundary elements (edges in this case) were not assigned a boundary condition functions so an entry is never made in the `advectiveFluxBoundaryConditionDict` leading to errors in the computation of the residuals.

The fix was to add constant BCs for the pressure and velocity variables in `setNonMaterial()` which is always called in `assembleDomain`.
 
Below are solution images that show the behavior with and without the fix for element-based partitioning:
![spatialToolsNoFix_vs_Fix](https://user-images.githubusercontent.com/7065326/55836311-2d483780-5aec-11e9-9cbf-8096291d46bf.png)

For reference, I've also attached an image with the fix using node-based partitioning to show that there are no visible changes to the results using the node-based partitioning workflow. 

![spatialTools_nodalPart_withFix](https://user-images.githubusercontent.com/7065326/55836598-05a59f00-5aed-11e9-8abd-2eed21695266.png)

