### PR TITLE
Possible fix for some nan values in advective_flux

### DIFF
--- a/proteus/mprans/RANS3PF2D.h
+++ b/proteus/mprans/RANS3PF2D.h
@@ -4453,11 +4453,7 @@ namespace proteus
                 }
                 else
                 {
-                  for (int i = 0; i < nParticles; i++)
-                  {
-                    double distance_to_i_th_solid = ebq_global_phi_solid[i * nElementBoundaries_global * nQuadraturePoints_elementBoundary + ebNE_kb];
-                    distance_to_omega_solid = (distance_to_i_th_solid < distance_to_omega_solid)?distance_to_i_th_solid:distance_to_omega_solid;
-                  }
+                  distance_to_omega_solid = ebq_global_phi_solid[ebN*nQuadraturePoints_elementBoundary+kb];
                 }
                 double eddy_viscosity_ext(0.),bc_eddy_viscosity_ext(0.); //not interested in saving boundary eddy viscosity for now
                 evaluateCoefficients(eps_rho,
@@ -6790,11 +6786,7 @@ namespace proteus
                 }
                 else
                 {
-                  for (int i = 0; i < nParticles; i++)
-                  {
-                    double distance_to_i_th_solid = ebq_global_phi_solid[i * nElementBoundaries_global * nQuadraturePoints_elementBoundary + ebNE_kb];
-                    distance_to_omega_solid = (distance_to_i_th_solid < distance_to_omega_solid)?distance_to_i_th_solid:distance_to_omega_solid;
-                  }
+                  distance_to_omega_solid = ebq_global_phi_solid[ebN*nQuadraturePoints_elementBoundary+kb];
                 }
                 double eddy_viscosity_ext(0.),bc_eddy_viscosity_ext(0.),rhoSave, nuSave;//not interested in saving boundary eddy viscosity for now
                 evaluateCoefficients(eps_rho,


### PR DESCRIPTION
The bug is about the variable `ebq_global_phi_solid` which has a different shape and its value is already the minimal distance to ALL particles. 