### PR TITLE
add `from sys import exit` to cython modules that use exit

### DIFF
--- a/proteus/cnumericalFlux.pyx
+++ b/proteus/cnumericalFlux.pyx
@@ -1,4 +1,5 @@
 # A type of -*- python -*- file
+from sys import exit
 import numpy as np
 cimport numpy as np
 cdef extern from "numericalFlux.h":


### PR DESCRIPTION
This fixes an error that only shows up when running jupyter notebooks.