### PR TITLE
Removed warnings from mprans

### DIFF
--- a/proteus/mprans/AddedMass.h
+++ b/proteus/mprans/AddedMass.h
@@ -166,17 +166,13 @@ namespace proteus
       for  (int k=0;k<nQuadraturePoints_element;k++)
         {
           //compute indeces and declare local storage
-          register int eN_k = eN*nQuadraturePoints_element+k,
-            eN_k_nSpace = eN_k*nSpace;
-            //eN_nDOF_trial_element = eN*nDOF_trial_element;
+          register int eN_k = eN*nQuadraturePoints_element+k;
           register double u=0.0,grad_u[nSpace],
             a=0.0,
-            f[nSpace],
             jac[nSpace*nSpace],
             jacDet,
             jacInv[nSpace*nSpace],
             u_grad_trial[nDOF_trial_element*nSpace],
-            u_test_dV[nDOF_trial_element],
             u_grad_test_dV[nDOF_test_element*nSpace],
             dV,x,y,z,
             G[nSpace*nSpace],G_dd_G,tr_G;
@@ -205,7 +201,6 @@ namespace proteus
           //precalculate test function products with integration weights
           for (int j=0;j<nDOF_trial_element;j++)
             {
-              u_test_dV[j] = u_test_ref[k*nDOF_trial_element+j]*dV;
               for (int I=0;I<nSpace;I++)
                 {
                   u_grad_test_dV[j*nSpace+I]   = u_grad_trial[j*nSpace+I]*dV;//cek warning won't work for Petrov-Galerkin
@@ -271,12 +266,11 @@ namespace proteus
         {
           for  (int k=0;k<nQuadraturePoints_element;k++)
             {
-              register int eN_k = eN*nQuadraturePoints_element+k;
               register double
                 jac[nSpace*nSpace],
                 jacDet,
                 jacInv[nSpace*nSpace],
-                dV,x,y,z;
+                x,y,z;
               ck.calculateMapping_element(eN,
                                           k,
                                           mesh_dof,
@@ -287,8 +281,6 @@ namespace proteus
                                           jacDet,
                                           jacInv,
                                           x,y,z);
-              //get the physical integration weight
-              dV = fabs(jacDet)*dV_ref[k];
             }
         }
       //
@@ -372,16 +364,11 @@ namespace proteus
             }//i
           for  (int kb=0;kb<nQuadraturePoints_elementBoundary;kb++)
             {
-              register int ebNE_kb = ebNE*nQuadraturePoints_elementBoundary+kb,
-                ebNE_kb_nSpace = ebNE_kb*nSpace,
-                ebN_local_kb = ebN_local*nQuadraturePoints_elementBoundary+kb,
+              register int ebN_local_kb = ebN_local*nQuadraturePoints_elementBoundary+kb,
                 ebN_local_kb_nSpace = ebN_local_kb*nSpace;
               register double penalty=0.0,
                 u_ext=0.0,
-                bc_u_ext=0.0,
-                adv_flux_ext=0.0,
                 diff_flux_ext=0.0,
-                a_ext,
                 jac_ext[nSpace*nSpace],
                 jacDet_ext,
                 jacInv_ext[nSpace*nSpace],
@@ -391,7 +378,6 @@ namespace proteus
                 dS,
                 u_test_dS[nDOF_test_element],
                 u_grad_trial_trace[nDOF_trial_element*nSpace],
-                u_grad_test_dS[nDOF_test_element*nSpace],
                 normal[nSpace],x_ext,y_ext,z_ext=0.0,
                 G[nSpace*nSpace],G_dd_G,tr_G;
               //
@@ -430,8 +416,6 @@ namespace proteus
               for (int j=0;j<nDOF_trial_element;j++)
                 {
                   u_test_dS[j] = u_test_trace_ref[ebN_local_kb*nDOF_test_element+j]*dS;
-                  for (int I=0;I<nSpace;I++)
-                    u_grad_test_dS[j*nSpace+I] = u_grad_trial_trace[j*nSpace+I]*dS;//cek hack, using trial
                 }
               //
               //calculate the numerical fluxes
@@ -560,21 +544,17 @@ namespace proteus
           }
       for  (int k=0;k<nQuadraturePoints_element;k++)
         {
-          int eN_k = eN*nQuadraturePoints_element+k, //index to a scalar at a quadrature point
-            eN_k_nSpace = eN_k*nSpace;
-            //eN_nDOF_trial_element = eN*nDOF_trial_element; //index to a vector at a quadrature point
+          int eN_k = eN*nQuadraturePoints_element+k; //index to a scalar at a quadrature point
 
           //declare local storage
           register double u=0.0,
             grad_u[nSpace],
-            f[nSpace],
             a=0.0,
             jac[nSpace*nSpace],
             jacDet,
             jacInv[nSpace*nSpace],
             u_grad_trial[nDOF_trial_element*nSpace],
             dV,
-            u_test_dV[nDOF_test_element],
             u_grad_test_dV[nDOF_test_element*nSpace],
             x,y,z,
             G[nSpace*nSpace],G_dd_G,tr_G;
@@ -603,7 +583,6 @@ namespace proteus
           //precalculate test function products with integration weights
           for (int j=0;j<nDOF_trial_element;j++)
             {
-              u_test_dV[j] = u_test_ref[k*nDOF_trial_element+j]*dV;
               for (int I=0;I<nSpace;I++)
                 {
                   u_grad_test_dV[j*nSpace+I]   = u_grad_trial[j*nSpace+I]*dV;//cek warning won't work for Petrov-Galerkin

--- a/proteus/mprans/Pres.h
+++ b/proteus/mprans/Pres.h
@@ -145,7 +145,6 @@ namespace proteus
         {
           elementResidual_u[i]=0.0;
         }//i
-      double epsHeaviside,epsDirac,epsDiffusion,norm;
       //loop over quadrature points and compute integrands
       for  (int k=0;k<nQuadraturePoints_element;k++)
         {
@@ -155,7 +154,7 @@ namespace proteus
             //eN_nDOF_trial_element = eN*nDOF_trial_element;
           register double u=0.0,grad_u[nSpace],
             f[nSpace],
-            r=0.0,dr=0.0,
+            r=0.0,
             jac[nSpace*nSpace],
             jacDet,
             jacInv[nSpace*nSpace],
@@ -349,11 +348,7 @@ namespace proteus
                 ebN_local_kb = ebN_local*nQuadraturePoints_elementBoundary+kb,
                 ebN_local_kb_nSpace = ebN_local_kb*nSpace;
               register double u_ext=0.0,
-                bc_u_ext=0.0,
                 adv_flux_ext=0.0,
-                diff_flux_ext=0.0,
-                a_ext,
-                f_ext[nSpace],
                 grad_u_ext[nSpace],
                 jac_ext[nSpace*nSpace],
                 jacDet_ext,
@@ -364,7 +359,6 @@ namespace proteus
                 dS,
                 u_test_dS[nDOF_test_element],
                 u_grad_trial_trace[nDOF_trial_element*nSpace],
-                u_grad_test_dS[nDOF_test_element*nSpace],
                 normal[nSpace],x_ext,y_ext,z_ext,
                 G[nSpace*nSpace],G_dd_G,tr_G;
               //
@@ -461,25 +455,15 @@ namespace proteus
           {
             elementJacobian_u_u[i*nDOF_trial_element+j]=0.0;
           }
-      double epsHeaviside,epsDirac,epsDiffusion;
       for  (int k=0;k<nQuadraturePoints_element;k++)
         {
-          int eN_k = eN*nQuadraturePoints_element+k, //index to a scalar at a quadrature point
-            eN_k_nSpace = eN_k*nSpace;
-            //eN_nDOF_trial_element = eN*nDOF_trial_element; //index to a vector at a quadrature point
-
           //declare local storage
-          register double u=0.0,
-            grad_u[nSpace],
-            r=0.0,dr=0.0,
-            jac[nSpace*nSpace],
+          register double jac[nSpace*nSpace],
             jacDet,
             jacInv[nSpace*nSpace],
-            u_grad_trial[nDOF_trial_element*nSpace],
             dV,
             u_test_dV[nDOF_test_element],
-            x,y,z,
-            G[nSpace*nSpace],G_dd_G,tr_G;
+            x,y,z;
           //
           //calculate solution and gradients at quadrature points
           //
@@ -501,14 +485,8 @@ namespace proteus
             }
           for(int i=0;i<nDOF_test_element;i++)
             {
-              //int eN_k_i=eN_k*nDOF_test_element+i;
-              //int eN_k_i_nSpace=eN_k_i*nSpace;
-              int i_nSpace=i*nSpace;
               for(int j=0;j<nDOF_trial_element;j++)
                 {
-                  //int eN_k_j=eN_k*nDOF_trial_element+j;
-                  //int eN_k_j_nSpace = eN_k_j*nSpace;
-                  int j_nSpace = j*nSpace;
                   elementJacobian_u_u[i*nDOF_trial_element+j] += ck.ReactionJacobian_weak(1.0,
                                                                                           u_trial_ref[k*nDOF_trial_element+j],
                                                                                           u_test_dV[i]);
@@ -547,10 +525,6 @@ namespace proteus
       for(int eN=0;eN<nElements_global;eN++)
         {
           register double  elementJacobian_u_u[nDOF_test_element*nDOF_trial_element];
-          for (int j=0;j<nDOF_trial_element;j++)
-            {
-              register int eN_j = eN*nDOF_trial_element+j;
-            }
           calculateElementJacobian(mesh_trial_ref,
                                    mesh_grad_trial_ref,
                                    mesh_dof,

--- a/proteus/mprans/PresInc.h
+++ b/proteus/mprans/PresInc.h
@@ -749,7 +749,6 @@ namespace proteus
             jacInv[nSpace*nSpace],
             u_grad_trial[nDOF_trial_element*nSpace],
             dV,
-            u_test_dV[nDOF_test_element],
             u_grad_test_dV[nDOF_test_element*nSpace],
             x,y,z,
             G[nSpace*nSpace],G_dd_G,tr_G;
@@ -778,7 +777,6 @@ namespace proteus
           //precalculate test function products with integration weights
           for (int j=0;j<nDOF_trial_element;j++)
             {
-              u_test_dV[j] = u_test_ref[k*nDOF_trial_element+j]*dV;
               for (int I=0;I<nSpace;I++)
                 {
                   u_grad_test_dV[j*nSpace+I]   = u_grad_trial[j*nSpace+I]*dV;//cek warning won't work for Petrov-Galerkin
@@ -932,18 +930,8 @@ namespace proteus
               register double h_b=0.0,
                 u_ext=0.0,
                 grad_u_ext[nSpace],
-                m_ext=0.0,
-                dm_ext=0.0,
                 a_ext=0.0,
                 f_ext[nSpace],
-                df_ext[nSpace],
-                dflux_u_u_ext=0.0,
-                bc_u_ext=0.0,
-                bc_m_ext=0.0,
-                bc_dm_ext=0.0,
-                bc_f_ext[nSpace],
-                bc_df_ext[nSpace],
-                fluxJacobian_u_u[nDOF_trial_element],
                 jac_ext[nSpace*nSpace],
                 jacDet_ext,
                 jacInv_ext[nSpace*nSpace],
@@ -954,8 +942,8 @@ namespace proteus
                 u_test_dS[nDOF_test_element],
                 u_grad_trial_trace[nDOF_trial_element*nSpace],
                 u_grad_test_dS[nDOF_test_element*nSpace],
-                normal[nSpace],x_ext,y_ext,z_ext,xt_ext,yt_ext,zt_ext,integralScaling,
-                    penalty=0.0,
+                normal[nSpace],x_ext,y_ext,z_ext,
+                penalty=0.0,
                 //
                 G[nSpace*nSpace],G_dd_G,tr_G;
               //

--- a/proteus/mprans/PresInit.h
+++ b/proteus/mprans/PresInit.h
@@ -482,25 +482,12 @@ namespace proteus
                 ebN_local_kb_nSpace = ebN_local_kb*nSpace;
               register double u_ext=0.0,
                 grad_u_ext[nSpace],
-                //m_ext=0.0,
-                //dm_ext=0.0,
-                //H_ext=0.0,
-                //dH_ext[nSpace],
-                //flux_ext=0.0,
-                //bc_u_ext=0.0,
-                //bc_grad_u_ext[nSpace],
-                //bc_m_ext=0.0,
-                //bc_dm_ext=0.0,
-                //bc_H_ext=0.0,
-                //bc_dH_ext[nSpace],
                 jac_ext[nSpace*nSpace],
                 jacDet_ext,
                 jacInv_ext[nSpace*nSpace],
                 boundaryJac[nSpace*(nSpace-1)],
                 metricTensor[(nSpace-1)*(nSpace-1)],
                 metricTensorDetSqrt,
-                dS,
-                //u_test_dS[nDOF_test_element],
                 u_grad_trial_trace[nDOF_trial_element*nSpace],
                 normal[nSpace],x_ext,y_ext,z_ext,
                 G[nSpace*nSpace],G_dd_G,tr_G,norm;
@@ -525,7 +512,6 @@ namespace proteus
                                                   normal_ref,
                                                   normal,
                                                   x_ext,y_ext,z_ext);
-              dS = metricTensorDetSqrt*dS_ref[kb];
               //get the metric tensor
               //cek todo use symmetry
               ck.calculateG(jacInv_ext,G,G_dd_G,tr_G);
@@ -599,9 +585,7 @@ namespace proteus
       double epsHeaviside,epsDirac,epsDiffusion;
       for  (int k=0;k<nQuadraturePoints_element;k++)
         {
-          int eN_k = eN*nQuadraturePoints_element+k, //index to a scalar at a quadrature point
-            eN_k_nSpace = eN_k*nSpace;
-            //eN_nDOF_trial_element = eN*nDOF_trial_element; //index to a vector at a quadrature point
+          int eN_k = eN*nQuadraturePoints_element+k; //index to a scalar at a quadrature point
 
           //declare local storage
           register double u=0.0,


### PR DESCRIPTION
The only remaining warning is about Numpy deprecated API.