### PR TITLE
Travis Build Speedup with build_ext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - conda info -a
   - conda env create -f environment-dev.yml
   - conda activate proteus-dev
+  - python setup.py build_ext
   - pip install -v -e .
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - conda info -a
   - conda env create -f environment-dev.yml
   - conda activate proteus-dev
-  - python setup.py build_ext
+  - python setup.py build_ext -i
   - pip install -v -e .
 
 cache:

--- a/setup.py
+++ b/setup.py
@@ -629,6 +629,7 @@ EXTENSIONS_TO_BUILD = [
 ]
 
 def setup_given_extensions(extensions):
+    print("worker id %d " % os.getpid (), extensions)
     setup(name='proteus',
           version='1.7.1.dev0',
           classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -936,12 +936,16 @@ def setup_given_extensions(extensions):
 def setup_extensions_in_sequential():
     setup_given_extensions(EXTENSIONS_TO_BUILD)
 
+def hello(number):
+    print("Hello Worker %d" % number)
+
 def setup_extensions_in_parallel():
     import multiprocessing, logging
     logger = multiprocessing.log_to_stderr()
     logger.setLevel(logging.INFO)
     multiprocessing.log_to_stderr()
     pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
+    pool.imap(hello, range(multiprocessing.cpu_count()))
     EXTENSIONS=[[e] for e in EXTENSIONS_TO_BUILD]
     pool.imap(setup_given_extensions, EXTENSIONS)
     pool.close()


### PR DESCRIPTION
Attempt at speeding up Travis build by explicitly calling `python setup.py build_ext` to make use of threads as per @cekees suggestion. 