### PR TITLE
Ensure openblas is compiled with openmp

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - metis
   - mpich
   - numpy =1.14.*
-  - openblas
+  - openblas =0.3.7=*_7
   - parmetis
   - petsc4py
   - petsc =3.12.*


### PR DESCRIPTION
`openblas` is compiled with `USE_OPENMP=1` from version `0.3.7`  build `7`. Previous to that `openblas` could hang.