### PR TITLE
TST: loosen gmsh test comparison

### DIFF
--- a/proteus/tests/test_gmsh_generation.py
+++ b/proteus/tests/test_gmsh_generation.py
@@ -16,7 +16,8 @@ logEvent("Testing Gmsh Mesh Conversion")
 
 
 #TEST VARIANCE THRESHOLD, 2%
-THRESHOLD = 0.02
+#THRESHOLD = 0.02
+THRESHOLD = 0.15
 
 #REFERENCE VALUES
 numNodes_reference_2D = 3433.0


### PR DESCRIPTION
Address issue #1078 

The comparison value for the gmsh test was changed. Tests will pass even if there's up to 15% deviation from the reference value.