### PR TITLE
TPF: fixes for MoveMesh, VOF, NCLS, MCorr

### DIFF
--- a/proteus/TwoPhaseFlow/utils/Parameters.py
+++ b/proteus/TwoPhaseFlow/utils/Parameters.py
@@ -1915,8 +1915,11 @@ class ParametersModelMoveMeshElastic(ParametersModelBase):
             assert mparams.rans2p.index is not None or mparams.rans3p.index is not None, 'RANS2P or RANS3PF must be used with VOF'
         # COEFFICIENTS
         coeffs = self.p.coefficients
+        coeffs.flowModelIndex = V_model
+        coeffs.meIndex = ME_model
         coeffs.modelType_block = smFlags
-        coeffs.modelType_block = smTypes
+        coeffs.modelParams_block = smTypes
+        coeffs.nd = nd
         coeffs.initialize()
         # INITIAL CONDITIONS
         self.p.initialConditions = None

--- a/proteus/TwoPhaseFlow/utils/Parameters.py
+++ b/proteus/TwoPhaseFlow/utils/Parameters.py
@@ -1319,8 +1319,8 @@ class ParametersModelVOF(ParametersModelBase):
         # COEFFICIENTS
         coeffs = self.p.coefficients
         coeffs.V_model = V_model
-        coeffs.RD_model = RD_model
-        coeffs.ME_model = ME_model
+        coeffs.RD_modelIndex = RD_model
+        coeffs.modelIndex = ME_model
         coeffs.movingDomain = self.p.movingDomain
         coeffs.initialize()
         # INITIAL CONDITIONS
@@ -1429,9 +1429,9 @@ class ParametersModelNCLS(ParametersModelBase):
             assert mparams.rans2p.index is not None or mparams.rans3p.index is not None, 'RANS2P or RANS3PF must be used with VOF'
         RD_model = mparams.rdls.index
         coeffs = self.p.coefficients
-        coeffs.V_model = V_model
-        coeffs.RD_model = RD_model
-        coeffs.ME_model = ME_model
+        coeffs.flowModelIndex = V_model
+        coeffs.RD_modelIndex = RD_model
+        coeffs.modelIndex = ME_model
         coeffs.movingDomain = self.p.movingDomain
         coeffs.initialize()
         # INITIAL CONDITIONS
@@ -1638,10 +1638,9 @@ class ParametersModelMCorr(ParametersModelBase):
             assert mparams.rans2p.index is not None or params.rans3p.index is not None, 'RANS2P or RANS3PF must be used with VOF'
         # COEFFICIENTS
         coeffs = self.p.coefficients
-        coeffs.LS_model = LS_model
-        coeffs.V_model = V_model
-        coeffs.ME_model = ME_model
-        coeffs.VOF_model = VOF_model
+        coeffs.flowModelIndex = V_model
+        coeffs.me_model = ME_model
+        coeffs.VOFModelIndex = VOF_model
         coeffs.nd = nd
         coeffs.initialize()
         # INITIAL CONDITIONS

--- a/proteus/mbd/CouplingFSI.pxd
+++ b/proteus/mbd/CouplingFSI.pxd
@@ -248,7 +248,7 @@ cdef class ProtChBody:
       object sdfIBM
       string hdfFileName
       double Aij_factor
-      int[:] boundaryFlags
+      np.ndarray boundaryFlags
     cdef np.ndarray callPrescribedMotion(self, double t)
 
 

--- a/proteus/mbd/CouplingFSI.pyx
+++ b/proteus/mbd/CouplingFSI.pyx
@@ -925,7 +925,7 @@ cdef class ProtChBody:
         self.position[:] = pyvec2array(self.ChBody.GetPos())
         # check if IBM and set index if not set previously by user
         if self.useIBM:
-            if self.boundaryFlags is None:
+            if not self.boundaryFlags:
                 self.setBoundaryFlags([self.ProtChSystem.nBodiesIBM])
             self.ProtChSystem.nBodiesIBM += 1
         # get the initial values for F and M


### PR DESCRIPTION
Addresses some issues introduced with latest update #1070 

(!) happened because some coefficients class (e.g. NCLS.py) have inconsistent `__init__` function arguments and class attributes (e.g. V_model -> flowModelIndex)