### PR TITLE
Submodules: relative paths converted to absolute paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "air-water-vv"]
 	path = air-water-vv
-	url = ../air-water-vv.git
+	url = git://github.com/erdc/air-water-vv.git
 	branch = master
 [submodule "stack"]
 	path = stack
-	url = ../stack
+	url = git://github.com/erdc/stack


### PR DESCRIPTION
This fixes issues of relative paths when cloning a fork of proteus, as the submodules are not necessarily forked with it (and therefore won't be found at e.g. `../air-water-vv`