### PR TITLE
Add .gitattributes that were not initially included 

### DIFF
--- a/proteus/tests/SWEs/dam_over_bumps/.gitattributes
+++ b/proteus/tests/SWEs/dam_over_bumps/.gitattributes
@@ -1,0 +1,6 @@
+hump.poly filter=lfs diff=lfs merge=lfs -text
+hump.1.neigh filter=lfs diff=lfs merge=lfs -text
+hump.1.poly filter=lfs diff=lfs merge=lfs -text
+hump.edge filter=lfs diff=lfs merge=lfs -text
+hump.ele filter=lfs diff=lfs merge=lfs -text
+hump.node filter=lfs diff=lfs merge=lfs -text

--- a/proteus/tests/SWEs/test_gauges/.gitattributes
+++ b/proteus/tests/SWEs/test_gauges/.gitattributes
@@ -1,0 +1,6 @@
+hump.poly filter=lfs diff=lfs merge=lfs -text
+hump.1.neigh filter=lfs diff=lfs merge=lfs -text
+hump.1.poly filter=lfs diff=lfs merge=lfs -text
+hump.edge filter=lfs diff=lfs merge=lfs -text
+hump.ele filter=lfs diff=lfs merge=lfs -text
+hump.node filter=lfs diff=lfs merge=lfs -text

--- a/proteus/tests/SWEs/test_reflecting_BCs/.gitattributes
+++ b/proteus/tests/SWEs/test_reflecting_BCs/.gitattributes
@@ -1,0 +1,6 @@
+tank2d.1.neigh filter=lfs diff=lfs merge=lfs -text
+tank2d.1.poly filter=lfs diff=lfs merge=lfs -text
+tank2d.edge filter=lfs diff=lfs merge=lfs -text
+tank2d.ele filter=lfs diff=lfs merge=lfs -text
+tank2d.node filter=lfs diff=lfs merge=lfs -text
+tank2d.poly filter=lfs diff=lfs merge=lfs -text

--- a/proteus/tests/SWFlow/comparison_files/.gitattributes
+++ b/proteus/tests/SWFlow/comparison_files/.gitattributes
@@ -1,3 +1,6 @@
-parab1D.h5 filter=lfs diff=lfs merge=lfs -text
-solitary.h5 filter=lfs diff=lfs merge=lfs -text
-dam3Bumps.h5 filter=lfs diff=lfs merge=lfs -text
+comparison_GN_steady_h_t2.csv filter=lfs diff=lfs merge=lfs -text
+comparison_dam3Bumps_h_t2.csv filter=lfs diff=lfs merge=lfs -text
+comparison_parab1D_h_t2.csv filter=lfs diff=lfs merge=lfs -text
+comparison_seawall_h_t2.csv filter=lfs diff=lfs merge=lfs -text
+comparison_solitary_reef_h_t2.csv filter=lfs diff=lfs merge=lfs -text
+comparison_solitary_wave_h_t2.csv filter=lfs diff=lfs merge=lfs -text

--- a/proteus/tests/cylinder2D/ibm_method/.gitattributes
+++ b/proteus/tests/cylinder2D/ibm_method/.gitattributes
@@ -1,4 +1,5 @@
 mesh.ele filter=lfs diff=lfs merge=lfs -text
+mesh.edge filter=lfs diff=lfs merge=lfs -text
 mesh.node filter=lfs diff=lfs merge=lfs -text
 mesh.poly filter=lfs diff=lfs merge=lfs -text
 mesh.1.neigh filter=lfs diff=lfs merge=lfs -text

--- a/proteus/tests/cylinder2D/ibm_method/.gitattributes
+++ b/proteus/tests/cylinder2D/ibm_method/.gitattributes
@@ -1,0 +1,5 @@
+mesh.ele filter=lfs diff=lfs merge=lfs -text
+mesh.node filter=lfs diff=lfs merge=lfs -text
+mesh.poly filter=lfs diff=lfs merge=lfs -text
+mesh.1.neigh filter=lfs diff=lfs merge=lfs -text
+mesh.1.poly filter=lfs diff=lfs merge=lfs -text

--- a/proteus/tests/griffiths_lane_6/.gitattributes
+++ b/proteus/tests/griffiths_lane_6/.gitattributes
@@ -1,0 +1,7 @@
+gl_6_3d.edge filter=lfs diff=lfs merge=lfs -text
+gl_6_3d.ele filter=lfs diff=lfs merge=lfs -text
+gl_6_3d.face filter=lfs diff=lfs merge=lfs -text
+gl_6_3d.neigh filter=lfs diff=lfs merge=lfs -text
+gl_6_3d.node filter=lfs diff=lfs merge=lfs -text
+gl_6_3d.ply filter=lfs diff=lfs merge=lfs -text
+gl_6_3d.poly filter=lfs diff=lfs merge=lfs -text

--- a/proteus/tests/surface_tension/rising_bubble_rans3p/comparison_files/.gitattributes
+++ b/proteus/tests/surface_tension/rising_bubble_rans3p/comparison_files/.gitattributes
@@ -1,4 +1,3 @@
-risingBubble_2D_ev.h5 filter=lfs diff=lfs merge=lfs -text
-risingBubble_2D_supg.h5 filter=lfs diff=lfs merge=lfs -text
-risingBubble_3D_ev.h5 filter=lfs diff=lfs merge=lfs -text
-risingBubble_3D_supg.h5 filter=lfs diff=lfs merge=lfs -text
+comparison_risingBubble_3D_ev_velocity_t2.csv filter=lfs diff=lfs merge=lfs -text
+comparison_risingBubble_3D_supg_velocity_t2.csv filter=lfs diff=lfs merge=lfs -text
+


### PR DESCRIPTION
Running tests can lead to unintended behavior with some comparison files because the .gitattributes files were not added.