### PR TITLE
Add PR template for long-term code quality

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+# Checklist
+
+Please ensure that the following criteria are met:
+
+[] If new files are being added, the files are no larger than 100kB.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,11 @@
-# Checklist
+# Mandatory Checklist
 
 Please ensure that the following criteria are met:
 
-[ ] If new files are being added, the files are no larger than 100kB.
+[ ] Title of pull request describes the changes/features
+[ ] Request at least 2 reviewers
+[ ] If new files are being added, the files are no larger than 100kB. Post the file sizes.
+[ ] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
+[ ] New features have appropriate documentation strings (readable by sphinx)
+
+As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 
 Please ensure that the following criteria are met:
 
-[] If new files are being added, the files are no larger than 100kB.
+[ ] If new files are being added, the files are no larger than 100kB.


### PR DESCRIPTION
This is mainly to address issue #1095 which is concerned with unnecessarily large files being added to the repo.

A pull request template is simply a body of text that will accompany any PR when it is created. For an official description: https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates#pull-request-templates

In the future, this can be used to provide guidance for new users as to how to develop for Proteus and therefore ensure some level of code quality. 

Some stringent additional guidelines can be:

- to include at least 1 test per PR (or create issues that reflect the need for tests)
- ensure new functions have descriptions that are parsable by readthedocs

