### PR TITLE
Add Conda-based Dockerfile

### DIFF
--- a/Dockerfile.conda
+++ b/Dockerfile.conda
@@ -1,0 +1,48 @@
+FROM erdc/conda_base:latest
+
+MAINTAINER Proteus Project <proteus@googlegroups.com>
+
+USER jovyan
+
+WORKDIR /home/$NB_USER
+
+ENV CC mpicc
+ENV CXX mpicxx
+ENV F77 mpif77
+ENV F90 mpif90
+
+RUN rm -rf proteus && \
+    git clone https://github.com/erdc/proteus && \
+    cd proteus && \
+    git checkout master && \
+    pip install -v -e . && \ 
+    CC=gcc CXX=g++ pip install matplotlib && \
+    PATH=/home/$NB_USER/proteus/linux/bin:$PATH make jupyter && \
+    CC=gcc CXX=g++ PATH=/home/$NB_USER/proteus/linux/bin:$PATH pip install jupyterhub && \
+    rm -rf build && \
+    rm -rf air-water-vv && \
+    rm -rf .git && \
+    rm -rf stack/.git && \
+    rm -rf /home/$NB_USER/.cache 
+
+#ENV PATH /home/$NB_USER/proteus/linux/bin:$PATH
+#ENV LD_LIBRARY_PATH /home/$NB_USER/proteus/linux/lib:$LD_LIBRARY_PATH
+
+USER root
+
+CMD ["start-notebook.sh"]
+
+# Add local files as late as possible to avoid cache busting
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/start.sh
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh /usr/local/bin/start-notebook.sh
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/start-singleuser.sh
+
+RUN chmod a+rx /usr/local/bin/*
+
+RUN ipython kernel install
+
+USER $NB_USER
+
+# Import matplotlib the first time to build the font cache.
+#ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
+#RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot"

--- a/Dockerfile.conda
+++ b/Dockerfile.conda
@@ -17,16 +17,13 @@ RUN rm -rf proteus && \
     git checkout master && \
     pip install -v -e . && \ 
     CC=gcc CXX=g++ pip install matplotlib && \
-    PATH=/home/$NB_USER/proteus/linux/bin:$PATH make jupyter && \
-    CC=gcc CXX=g++ PATH=/home/$NB_USER/proteus/linux/bin:$PATH pip install jupyterhub && \
+    make jupyter && \
+    CC=gcc CXX=g++ pip install jupyterhub && \
     rm -rf build && \
     rm -rf air-water-vv && \
     rm -rf .git && \
     rm -rf stack/.git && \
     rm -rf /home/$NB_USER/.cache 
-
-#ENV PATH /home/$NB_USER/proteus/linux/bin:$PATH
-#ENV LD_LIBRARY_PATH /home/$NB_USER/proteus/linux/lib:$LD_LIBRARY_PATH
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,6 @@ jupyter:
 	@echo "************************************"
 	@echo "Enabling jupyter notebook/widgets"
 ifdef CONDA_PREFIX
-	continue
 else
 	source ${PROTEUS_PREFIX}/bin/proteus_env.sh
 endif

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,11 @@ test-conda: air-water-vv check
 jupyter:
 	@echo "************************************"
 	@echo "Enabling jupyter notebook/widgets"
+ifdef CONDA_PREFIX
+	continue
+else
+	source ${PROTEUS_PREFIX}/bin/proteus_env.sh
+endif
 	source ${PROTEUS_PREFIX}/bin/proteus_env.sh
 	pip install configparser ipyparallel ipython terminado jupyter ipywidgets ipyleaflet jupyter_dashboards pythreejs rise cesiumpy ipympl sympy transforms3d ipymesh voila ipyvolume ipysheet xonsh[ptk,linux,proctitle] ipytree
 	ipcluster nbextension enable --user
@@ -344,7 +349,11 @@ jupyter:
 	printf "c.LocalControllerLauncher.controller_cmd = ['python', '-m', 'ipyparallel.controller']\n" >> ${HOME}/.ipython/profile_mpi/ipcluster_config.py
 	printf "c.LocalEngineSetLauncher.engine_cmd = ['python', '-m', 'ipyparallel.engine']\n" >> ${HOME}/.ipython/profile_mpi/ipcluster_config.py
 	printf "c.MPIEngineSetLauncher.engine_cmd = ['python', '-m', 'ipyparallel.engine']\n" >> ${HOME}/.ipython/profile_mpi/ipcluster_config.py
+ifdef CONDA_PREFIX
+	cd ${CONDA_PREFIX}/lib/python3.7/site-packages/notebook/static/components/react && wget https://unpkg.com/react-dom@16/umd/react-dom.production.min.js
+else
 	cd linux/lib/python3.7/site-packages/notebook/static/components/react && wget https://unpkg.com/react-dom@16/umd/react-dom.production.min.js
+endif
 
 jupyterlab:
 	@echo "************************************"

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,6 @@ ifdef CONDA_PREFIX
 else
 	source ${PROTEUS_PREFIX}/bin/proteus_env.sh
 endif
-	source ${PROTEUS_PREFIX}/bin/proteus_env.sh
 	pip install configparser ipyparallel ipython terminado jupyter ipywidgets ipyleaflet jupyter_dashboards pythreejs rise cesiumpy ipympl sympy transforms3d ipymesh voila ipyvolume ipysheet xonsh[ptk,linux,proctitle] ipytree
 	ipcluster nbextension enable --user
 	jupyter nbextension enable --py --sys-prefix ipysheet


### PR DESCRIPTION
# Mandatory Checklist

Please ensure that the following criteria are met:

- [x] Title of pull request describes the changes/features
- [x] Request at least 2 reviewers
- [x] If new files are being added, the files are no larger than 100kB. Post the file sizes.
- [x] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
- [x] New features have appropriate documentation strings (readable by sphinx)
- [x] Contributor has read and agreed with CONTRIBUTING.md and has added themselves to CONTRIBUTORS.md 

As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

# Description

This PR adds `Dockerfile.conda` which provides a recipe to build a container from the `erdc/conda_base` DockerHub repo and installs proteus using the active proteus-dev environment. 

The conda environment yields 3+GB container vs the 2GB container from hashstack.

The Makefile was modified to allow for the jupyter installation. It's unclear if the remainder of the Dockerfile executes properly.
```
USER root

CMD ["start-notebook.sh"]

# Add local files as late as possible to avoid cache busting
ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/start.sh
ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh /usr/local/bin/start-notebook.sh
ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/start-singleuser.sh

RUN chmod a+rx /usr/local/bin/*

RUN ipython kernel install

USER $NB_USER

# Import matplotlib the first time to build the font cache.
#ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
#RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot"
```

New File Sizes:
`4.0K Dockerfile.conda`