### PR TITLE
fix some problems with rans3p with new pybind11/cArgumentsDict

### DIFF
--- a/proteus/mprans/RANS3PF.py
+++ b/proteus/mprans/RANS3PF.py
@@ -3071,7 +3071,7 @@ class LevelModel(proteus.Transport.OneLevelTransport):
             argsDict["vel_trial_trace_ref"] = self.u[0].femSpace.psi_trace
             argsDict["ebqe_velocity"] = self.ebqe[('velocity', 0)]
             argsDict["velocityAverage"] = self.ebq_global[('velocityAverage', 0)]
-            self.rans3pf.calculateVelocityAverage(args)
+            self.rans3pf.calculateVelocityAverage(argsDict)
             if self.movingDomain:
                 log("Element Quadrature", level=3)
                 self.calculateElementQuadrature(domainMoved=True)

--- a/proteus/mprans/RANS3PSed.py
+++ b/proteus/mprans/RANS3PSed.py
@@ -26,6 +26,7 @@ from proteus.SubgridError import SGE_base
 from proteus.ShockCapturing import ShockCapturing_base
 from . import cRANS3PSed
 from . import cRANS3PSed2D
+from . import cArgumentsDict
 
 
 class SubgridError(proteus.SubgridError.SGE_base):
@@ -234,7 +235,7 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
         self.movingDomain = movingDomain
         self.epsFact_solid = epsFact_solid
         self.useConstant_he = useConstant_he
-        self.useVF = useVF
+        self.useVF = float(useVF)
         self.useRBLES = useRBLES
         self.useMetrics = useMetrics
         self.sd = sd
@@ -1731,7 +1732,7 @@ class LevelModel(proteus.Transport.OneLevelTransport):
         argsDict["nu_0"] = self.coefficients.nu_0
         argsDict["rho_1"] = self.coefficients.rho_1
         argsDict["nu_1"] = self.coefficients.nu_1
-        argsDict["rho_s"] = self.coefficients.rho_s
+        argsDict["rho_s"] = float(self.coefficients.rho_s)
         argsDict["smagorinskyConstant"] = self.coefficients.smagorinskyConstant
         argsDict["turbulenceClosureModel"] = self.coefficients.turbulenceClosureModel
         argsDict["Ct_sge"] = self.Ct_sge
@@ -1758,7 +1759,7 @@ class LevelModel(proteus.Transport.OneLevelTransport):
         argsDict["v_dof"] = self.u[1].dof
         argsDict["w_dof"] = self.u[2].dof
         argsDict["g"] = self.coefficients.g
-        argsDict["useVF"] = self.coefficients.useVF
+        argsDict["useVF"] = float(self.coefficients.useVF)
         argsDict["vf"] = self.coefficients.q_vf
         argsDict["phi"] = self.coefficients.q_phi
         argsDict["normal_phi"] = self.coefficients.q_n
@@ -1957,7 +1958,7 @@ class LevelModel(proteus.Transport.OneLevelTransport):
         argsDict["nu_0"] = self.coefficients.nu_0
         argsDict["rho_1"] = self.coefficients.rho_1
         argsDict["nu_1"] = self.coefficients.nu_1
-        argsDict["rho_s"] = self.coefficients.rho_s
+        argsDict["rho_s"] = float(self.coefficients.rho_s)
         argsDict["smagorinskyConstant"] = self.coefficients.smagorinskyConstant
         argsDict["turbulenceClosureModel"] = self.coefficients.turbulenceClosureModel
         argsDict["Ct_sge"] = self.Ct_sge

--- a/proteus/mprans/SedClosure.cpp
+++ b/proteus/mprans/SedClosure.cpp
@@ -23,7 +23,24 @@ PYBIND11_MODULE(SedClosure, m)
     py::class_<cppHsuSedStress2D>(m, "HsuSedStress")
         .def(py::init<double, double, double, double, double, double, double, double,
                       double, double, double, double, double, double, double, double,
-                      double>())
+	     double>(),
+	     py::arg("aDarcy"),
+	     py::arg("betaForch"),
+	     py::arg("grain"),
+	     py::arg("packFraction"),
+	     py::arg("packMargin"),
+	     py::arg("maxFraction"),
+	     py::arg("frFraction"),
+	     py::arg("sigmaC"),
+	     py::arg("C3e"),
+	     py::arg("C4e"),
+	     py::arg("eR"),
+	     py::arg("fContact"),
+	     py::arg("mContact"),
+	     py::arg("nContact"),
+	     py::arg("angFriction"),
+	     py::arg("vos_limiter"),
+	     py::arg("mu_fr_limiter"))
         .def_readonly("aDarcy", &cppHsuSedStress2D::aDarcy_)
         .def_readonly("betaForch", &cppHsuSedStress2D::betaForch_)
         .def_readonly("grain", &cppHsuSedStress2D::grain_)

--- a/proteus/mprans/VOS3P.py
+++ b/proteus/mprans/VOS3P.py
@@ -1233,7 +1233,7 @@ class LevelModel(proteus.Transport.OneLevelTransport):
         argsDict["global_max_u"] = self.coefficients.global_max_u
         argsDict["csrRowIndeces_DofLoops"] = rowptr
         argsDict["csrColumnOffsets_DofLoops"] = colind
-        self.vos.kth_FCT_step(args)
+        self.vos.kth_FCT_step(argsDict)
         self.timeIntegration.u[:] = limited_solution
         fromFreeToGlobal=1 #direction copying
         cfemIntegrals.copyBetweenFreeUnknownsAndGlobalUnknowns(fromFreeToGlobal,


### PR DESCRIPTION
This fixes some issues:
 - missing import of cArgumentsDict in RANS3PSed
 - missing definition of keyword arguments in SedimentClosure.cpp
 - several instances where 'arg' was used instead of 'argsDict'

@acatwithacomputer you may also need to update some of the input files for the sediment tests to 1) ensure that floating point numbers are used for floating point parameters,  otherwise you'll get an error that the parameter is not available (e.g. use rho_s = 1.0, not 1, etc.) 2) We got rid of the RDLS3P class because it was redundant, so you may need get errors trying to import RDLS3P--just change it to RDLS.

/cc @JohanMabille 

# Mandatory Checklist

Please ensure that the following criteria are met:

- [ ] Title of pull request describes the changes/features
- [ ] Request at least 2 reviewers
- [ ] If new files are being added, the files are no larger than 100kB. Post the file sizes.
- [ ] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
- [ ] New features have appropriate documentation strings (readable by sphinx)
- [ ] Contributor has read and agreed with CONTRIBUTING.md and has added themselves to CONTRIBUTORS.md 

As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

# Description
