### PR TITLE
Fix MoveMesh cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
       - PATH=./linux/bin:$PATH MPLBACKEND=Agg py.test -n 1 --dist=loadfile --forked -v proteus/tests --ignore proteus/tests/POD --cov=proteus
       - PATH=./linux/bin:$PATH MPLBACKEND=Agg py.test -n 1 --dist=loadfile --forked -v air-water-vv/Tests/1st_set --cov=proteus
       - PATH=./linux/bin:$PATH MPLBACKEND=Agg py.test -n 1 --dist=loadfile --forked -v air-water-vv/Tests/2nd_set --cov=proteus
+      - PATH=./linux/bin:$PATH MPLBACKEND=Agg mpiexec -np 2 pytest -v proteus/tests/FSI
   - stage: test
     name: "conda linux"
     os: linux
@@ -82,6 +83,7 @@ jobs:
       - py.test -n 1 --dist=loadfile --forked -v proteus/tests --ignore proteus/tests/POD --cov=proteus
       - MPLBACKEND=Agg py.test -n 1 --dist=loadfile --forked -v air-water-vv/Tests/1st_set
       - MPLBACKEND=Agg py.test -n 1 --dist=loadfile --forked -v air-water-vv/Tests/2nd_set
+      - MPLBACKEND=Agg mpiexec -np 2 pytest -v proteus/tests/FSI
     deploy:
       provider: script
       script: bash ./scripts/deploy.sh docs

--- a/proteus/mprans/MoveMesh.py
+++ b/proteus/mprans/MoveMesh.py
@@ -149,10 +149,10 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
         #TODO: unclear if this needs to apply to all mesh types
         if self.nd == 2:  
            cmeshTools.computeGeometricInfo_triangle(self.mesh.subdomainMesh.cmesh)
-           self.mesh.buildFromC(self.mesh.cmesh)
+           self.mesh.subdomainMesh.buildFromC(self.mesh.subdomainMesh.cmesh)
         if self.nd == 3:  
            cmeshTools.computeGeometricInfo_tetrahedron(self.mesh.subdomainMesh.cmesh)
-           self.mesh.buildFromC(self.mesh.cmesh)
+           self.mesh.subdomainMesh.buildFromC(self.mesh.subdomainMesh.cmesh)
 
         copyInstructions = {'clear_uList': True}
         return copyInstructions

--- a/proteus/mprans/MoveMesh.py
+++ b/proteus/mprans/MoveMesh.py
@@ -149,10 +149,8 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
         #TODO: unclear if this needs to apply to all mesh types
         if self.nd == 2:  
            cmeshTools.computeGeometricInfo_triangle(self.mesh.subdomainMesh.cmesh)
-           self.mesh.subdomainMesh.buildFromC(self.mesh.subdomainMesh.cmesh)
         if self.nd == 3:  
            cmeshTools.computeGeometricInfo_tetrahedron(self.mesh.subdomainMesh.cmesh)
-           self.mesh.subdomainMesh.buildFromC(self.mesh.subdomainMesh.cmesh)
 
         copyInstructions = {'clear_uList': True}
         return copyInstructions

--- a/proteus/mprans/MoveMesh.py
+++ b/proteus/mprans/MoveMesh.py
@@ -146,11 +146,12 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
         self.dt_last = self.model.timeIntegration.dt
 
         #update nodal/element diameters:
-        #TODO: unclear if this needs to apply to all mesh types
-        if self.nd == 2:  
-           cmeshTools.computeGeometricInfo_triangle(self.mesh.subdomainMesh.cmesh)
-        if self.nd == 3:  
-           cmeshTools.computeGeometricInfo_tetrahedron(self.mesh.subdomainMesh.cmesh)
+        #TODO: unclear if this needs to apply to all mesh types, look into parallel communication of geometric info
+        #if self.nd == 2:  
+        #   #cmeshTools.computeGeometricInfo_triangle(self.mesh.cmesh)
+        #   cmeshTools.computeGeometricInfo_triangle(self.mesh.subdomainMesh.cmesh)
+        #if self.nd == 3:  
+        #   cmeshTools.computeGeometricInfo_tetrahedron(self.mesh.subdomainMesh.cmesh)
 
         copyInstructions = {'clear_uList': True}
         return copyInstructions

--- a/proteus/tests/FSI/test_FSI.py
+++ b/proteus/tests/FSI/test_FSI.py
@@ -232,7 +232,8 @@ class TestIBM(unittest.TestCase):
         ns.calculateSolution('floatingCubeALE')
         pos = case.body.getPosition()
 
-        npt.assert_almost_equal(pos, np.array([0.49945, 0.50047, 0.50807]), decimal=5)
+        #npt.assert_almost_equal(pos, np.array([0.49945, 0.50047, 0.50807]), decimal=5)
+        npt.assert_almost_equal(pos, np.array([0.49947, 0.50047, 0.5081 ]), decimal=5)
         #self.teardown_method(self)
 
 if __name__ == "__main__":

--- a/proteus/tests/FSI/test_FSI.py
+++ b/proteus/tests/FSI/test_FSI.py
@@ -43,7 +43,7 @@ class TestIBM(unittest.TestCase):
                     'addedmass3D_so.log'
                     ]
         for file in FileList:
-            if os.path.isfile(file):
+            if os.path.isfile(file) and comm.isMaster():
                 os.remove(file)
             else:
                 pass

--- a/proteus/tests/FSI/test_FSI.py
+++ b/proteus/tests/FSI/test_FSI.py
@@ -5,7 +5,7 @@ from builtins import range
 import os
 import pytest
 from proteus.iproteus import opts, default_s
-from proteus import Profiling, NumericalSolution
+from proteus import Profiling, NumericalSolution, Comm
 import unittest
 import numpy as np
 import numpy.testing as npt
@@ -15,6 +15,7 @@ import importlib
 import pytest
 
 modulepath = os.path.dirname(os.path.abspath(__file__))
+comm = Comm.init()
 
 class TestIBM(unittest.TestCase):
 

--- a/proteus/tests/FSI/test_FSI.py
+++ b/proteus/tests/FSI/test_FSI.py
@@ -232,8 +232,7 @@ class TestIBM(unittest.TestCase):
         ns.calculateSolution('floatingCubeALE')
         pos = case.body.getPosition()
 
-        #npt.assert_almost_equal(pos, np.array([0.49945, 0.50047, 0.50807]), decimal=5)
-        npt.assert_almost_equal(pos, np.array([0.49947, 0.50047, 0.5081 ]), decimal=5)
+        npt.assert_almost_equal(pos, np.array([0.49945, 0.50047, 0.50807]), decimal=5)
         #self.teardown_method(self)
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Mandatory Checklist

Please ensure that the following criteria are met:

- [ ] Title of pull request describes the changes/features
- [ ] Request at least 2 reviewers
- [ ] If new files are being added, the files are no larger than 100kB. Post the file sizes.
- [ ] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
- [x] New features have appropriate documentation strings (readable by sphinx)
- [x] Contributor has read and agreed with CONTRIBUTING.md and has added themselves to CONTRIBUTORS.md 

As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

# Description
Addresses #1208

https://github.com/erdc/proteus/commit/8e7c357baa9ed44d11fb404415bc6f7950dd6abe introduced an error in the postStep for MoveMesh in parallel. Specifically, the global mesh object was being updated instead of the subdomain mesh object, leading to a bookkeeping error. 

A parallel test command is added to Travis in the FSI directory for testing/covering this behavior.

