### PR TITLE
Skip boundarys with non-positive tags (ghost boundaries)

### DIFF
--- a/proteus/mprans/RANS2P.h
+++ b/proteus/mprans/RANS2P.h
@@ -3630,6 +3630,8 @@ namespace proteus
             ebN_local = elementBoundaryLocalElementBoundariesArray.data()[ebN*2+0],
             eN_nDOF_trial_element = eN*nDOF_trial_element,
             eN_nDOF_v_trial_element = eN*nDOF_v_trial_element;
+	  if (boundaryFlags[ebN] < 1)
+	    continue;
           register double elementResidual_mesh[nDOF_test_element],
             elementResidual_p[nDOF_test_element],
             elementResidual_u[nDOF_v_test_element],
@@ -4512,10 +4514,9 @@ namespace proteus
               //
               //update residuals
               //
-              //if(true)//boundaryFlags[ebN] > 0)
               const double H_s = gf_s.H(particle_eps, ebqe_phi_s.data()[ebNE_kb]);
               if (elementIsActive[eN])
-                { //if boundary flag positive, then include flux contributions on interpart boundaries
+                { 
                   total_flux += flux_mass_ext*dS;
                   for (int i=0;i<nDOF_test_element;i++)
                     {
@@ -6540,6 +6541,8 @@ namespace proteus
             eN_nDOF_trial_element = eN*nDOF_trial_element,
             eN_nDOF_v_trial_element = eN*nDOF_v_trial_element,
             ebN_local = elementBoundaryLocalElementBoundariesArray.data()[ebN*2+0];
+	  if (boundaryFlags[ebN] < 1)
+	    continue;
           register double eps_rho,eps_mu;
           double element_phi[nDOF_mesh_trial_element], element_phi_s[nDOF_mesh_trial_element];
           for (int j=0;j<nDOF_mesh_trial_element;j++)
@@ -7256,7 +7259,6 @@ namespace proteus
               ck.calculateGScale(G,normal,h_penalty);
               penalty = useMetrics*C_b/h_penalty + (1.0-useMetrics)*ebqe_penalty_ext.data()[ebNE_kb];
               if (elementIsActive[eN])
-                //                if(true)//boundaryFlags[ebN] > 0)
                 { //if boundary flag positive, then include flux contributions on interpart boundaries
                   for (int j=0;j<nDOF_trial_element;j++)
                     {
@@ -7383,7 +7385,7 @@ namespace proteus
                                                                &vel_grad_trial_trace[j_nSpace],
                                                                penalty);//ebqe_penalty_ext.data()[ebNE_kb]);
                     }//j
-                }//if boundaryFlags.data()[ebN] positive
+                }
               //
               //update the global Jacobian from the flux Jacobian
               //

--- a/proteus/mprans/RANS2P2D.h
+++ b/proteus/mprans/RANS2P2D.h
@@ -3037,6 +3037,8 @@ namespace proteus
             ebN_local = elementBoundaryLocalElementBoundariesArray.data()[ebN*2+0],
             eN_nDOF_trial_element = eN*nDOF_trial_element,
             eN_nDOF_v_trial_element = eN*nDOF_v_trial_element;
+	  if (boundaryFlags[ebN] < 1)
+	    continue;
           register double elementResidual_mesh[nDOF_test_element],
             elementResidual_p[nDOF_test_element],
             elementResidual_u[nDOF_v_test_element],
@@ -3798,7 +3800,6 @@ namespace proteus
               //
               //update residuals
               //
-              //if(true)//boundaryFlags[ebN] > 0)
               const double H_s = gf_s.H(particle_eps, ebqe_phi_s.data()[ebNE_kb]);
               if (elementIsActive[eN])
                 { //if boundary flag positive, then include flux contributions on interpart boundaries
@@ -5596,6 +5597,8 @@ namespace proteus
             eN_nDOF_trial_element = eN*nDOF_trial_element,
             eN_nDOF_v_trial_element = eN*nDOF_v_trial_element,
             ebN_local = elementBoundaryLocalElementBoundariesArray.data()[ebN*2+0];
+	  if (boundaryFlags[ebN] < 1)
+	    continue;
           register double eps_rho,eps_mu;
           double element_phi[nDOF_mesh_trial_element], element_phi_s[nDOF_mesh_trial_element];
           for (int j=0;j<nDOF_mesh_trial_element;j++)


### PR DESCRIPTION
This is re-enabling a default behavior for boundaries tagged zero or less. That is, skip them. I used a continue statement so this happens at the top level of the loop so there are no calculations or contributions on boundaryFlag < 1.

# Mandatory Checklist

Please ensure that the following criteria are met:

- [x] Title of pull request describes the changes/features
- [x] Request at least 2 reviewers
- [x] If new files are being added, the files are no larger than 100kB. Post the file sizes.
- [x] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
- [ ] New features have appropriate documentation strings (readable by sphinx)
- [x] Contributor has read and agreed with CONTRIBUTING.md and has added themselves to CONTRIBUTORS.md 

As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

# Description
