### PR TITLE
Simplify and reorganize TPF attributes under more descriptive categories

### DIFF
--- a/proteus/TwoPhaseFlow/TwoPhaseFlowProblem.py
+++ b/proteus/TwoPhaseFlow/TwoPhaseFlowProblem.py
@@ -17,11 +17,9 @@ class TwoPhaseFlowProblem:
                  models=None, #list of models
                  # TIME STEPPING #
                  cfl=0.33,
-                 outputStepping=None,
                  # DOMAIN AND MESH #
-                 structured=False,
                  domain=None,
-                 triangleFlag=0,
+                 mesh=None,
                  # INITIAL CONDITIONS #
                  initialConditions=None,
                  # BOUNDARY CONDITIONS #
@@ -34,12 +32,12 @@ class TwoPhaseFlowProblem:
         # ***** SAVE PARAMETERS ***** #
         self.useExact=useExact
         self.domain=domain
-        self.mesh = None
+        self.mesh = mesh
         self.modelList=[] #list used for internal tracking of models
         self.modelDict={} #dict used to allow user access to models
         self.modelIdxDict = {} #dict used for internal tracking of model indices
         self.cfl=cfl
-        self.outputStepping=outputStepping
+        self.outputStepping=OutputStepping()
         self.so = System_base()
         self.initialConditions=initialConditions
         self.boundaryConditions=boundaryConditions
@@ -249,24 +247,19 @@ class OutputStepping:
     """
     OutputStepping handles how often the solution is outputted.
     """
-    def __init__(self,
-                 final_time,
-                 dt_init=0.001,
-                 dt_output=None,
-                 nDTout=None,
-                 dt_fixed=None):
-        self.final_time=final_time
-        self.dt_init=dt_init
-        assert not (dt_output is None and nDTout is None), "Provide dt_output or nDTout"
-        self.dt_output=dt_output
-        self.nDTout = nDTout
-        self.dt_fixed = dt_fixed
+    def __init__(self):
+        self.final_time=None 
+        self.dt_init=0.001
+        self.dt_output=None
+        self.nDTout = None
+        self.dt_fixed = None
         self.systemStepExact = False
 
     def __getitem__(self, key):
         return self.__dict__[key]
 
     def setOutputStepping(self):
+        assert not (self.dt_output is None and nDTout is None), "Provide dt_output or nDTout"
         # COMPUTE dt_init #
         self.dt_init = min(self.dt_output, self.dt_init)
         if self.nDTout is None:

--- a/proteus/TwoPhaseFlow/utils/Parameters.py
+++ b/proteus/TwoPhaseFlow/utils/Parameters.py
@@ -187,7 +187,7 @@ class ParametersModelBase(FreezableClass):
     def initializePhysics(self):
         self.p.domain = self._Problem.domain
         self.p.nd = self._Problem.domain.nd
-        self.p.movingDomain = self._Problem.movingDomain
+        self.p.movingDomain = self._Problem.SystemPhysics.movingDomain
         self.p.genMesh = self._Problem.Parameters.mesh.genMesh
         # initialize extra parameters
         self._initializePhysics()
@@ -209,7 +209,7 @@ class ParametersModelBase(FreezableClass):
        
 
     def initializeNumerics(self):
-        self.n.runCFL = self._Problem.cfl
+        self.n.runCFL = self._Problem.SystemNumerics.cfl
         # MESH
         mesh = self._Problem.Parameters.mesh
         self.n.triangleFlag = mesh.triangleFlag
@@ -221,13 +221,13 @@ class ParametersModelBase(FreezableClass):
         self.n.nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
         self.n.restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
         # TIME INTEGRATION
-        self.n.runCFL = self._Problem.cfl
+        self.n.runCFL = self._Problem.SystemNumerics.cfl
         # FINITE ELEMENT SPACES
         FESpace = self._Problem.FESpace
         self.n.elementQuadrature = FESpace['elementQuadrature']
         self.n.elementBoundaryQuadrature = FESpace['elementBoundaryQuadrature']
         # SUPERLU
-        if self._Problem.useSuperlu and not parallel:
+        if self._Problem.SystemNumerics.useSuperlu and not parallel:
             self.n.multilevelLinearSolver = LinearSolvers.LU
             self.n.levelLinearSolver = LinearSolvers.LU
         # AUXILIARY VARIABLES
@@ -241,7 +241,7 @@ class ParametersModelBase(FreezableClass):
         pass
 
     def initializePETScOptions(self):
-        if not self._Problem.usePETScOptionsFileExternal:
+        if not self._Problem.SystemNumerics.usePETScOptionsFileExternal:
             # use default options if no file
             self._initializePETScOptions()
         else:
@@ -431,7 +431,7 @@ class ParametersModelRANS2P(ParametersModelBase):
 
     def _initializePETScOptions(self):
         prefix = self.n.linear_solver_options_prefix
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.OptDB.setValue(prefix+'ksp_type', 'preonly')
             self.OptDB.setValue(prefix+'pc_type', 'lu')
             self.OptDB.setValue(prefix+'pc_factor_mat_solver_type', 'superlu_dist')
@@ -781,7 +781,7 @@ class ParametersModelPressureInitial(ParametersModelBase):
         FESpace = self._Problem.FESpace
         self.n.femSpaces = {0: FESpace['pBasis']}
         # LINEAR ALGEBRA
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.n.linearSmoother = None
         # TOLERANCE
         mesh = self._Problem.Parameters.mesh
@@ -862,7 +862,7 @@ class ParametersModelPressureIncrement(ParametersModelBase):
         FESpace = self._Problem.FESpace
         self.n.femSpaces = {0: FESpace['pBasis']}
         # LINEAR ALGEBRA
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.n.linearSmoother = None
         # TOLERANCE
         mesh = self._Problem.Parameters.mesh
@@ -1315,7 +1315,7 @@ class ParametersModelVOF(ParametersModelBase):
 
     def _initializePETScOptions(self):
         prefix = self.n.linear_solver_options_prefix
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.OptDB.setValue(prefix+'ksp_type', 'preonly')
             self.OptDB.setValue(prefix+'pc_type', 'lu')
             self.OptDB.setValue(prefix+'pc_factor_mat_solver_type', 'superlu_dist')
@@ -1427,7 +1427,7 @@ class ParametersModelNCLS(ParametersModelBase):
 
     def _initializePETScOptions(self):
         prefix = self.n.linear_solver_options_prefix
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.OptDB.setValue(prefix+'ksp_type', 'preonly')
             self.OptDB.setValue(prefix+'pc_type', 'lu')
             self.OptDB.setValue(prefix+'pc_factor_mat_solver_type', 'superlu_dist')
@@ -1524,7 +1524,7 @@ class ParametersModelRDLS(ParametersModelBase):
 
     def _initializePETScOptions(self):
         prefix = self.n.linear_solver_options_prefix
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.OptDB.setValue(prefix+'ksp_type', 'preonly')
             self.OptDB.setValue(prefix+'pc_type', 'lu')
             self.OptDB.setValue(prefix+'pc_factor_mat_solver_type', 'superlu_dist')
@@ -1625,7 +1625,7 @@ class ParametersModelMCorr(ParametersModelBase):
         
     def _initializePETScOptions(self):
         prefix = self.n.linear_solver_options_prefix
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.OptDB.setValue(prefix+'ksp_type', 'preonly')
             self.OptDB.setValue(prefix+'pc_type', 'lu')
             self.OptDB.setValue(prefix+'pc_factor_mat_solver_type', 'superlu_dist')
@@ -1716,7 +1716,7 @@ class ParametersModelAddedMass(ParametersModelBase):
 
     def _initializePETScOptions(self):
         prefix = self.n.linear_solver_options_prefix
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.OptDB.setValue(prefix+'ksp_type', 'preonly')
             self.OptDB.setValue(prefix+'pc_type', 'lu')
             self.OptDB.setValue(prefix+'pc_factor_mat_solver_type', 'superlu_dist')
@@ -1925,7 +1925,7 @@ class ParametersModelMoveMeshElastic(ParametersModelBase):
 
     def _initializePETScOptions(self):
         prefix = self.n.linear_solver_options_prefix
-        if self._Problem.useSuperlu:
+        if self._Problem.SystemNumerics.useSuperlu:
             self.OptDB.setValue(prefix+'ksp_type', 'preonly')
             self.OptDB.setValue(prefix+'pc_type', 'lu')
             self.OptDB.setValue(prefix+'pc_factor_mat_solver_type', 'superlu_dist')

--- a/proteus/TwoPhaseFlow/utils/Parameters.py
+++ b/proteus/TwoPhaseFlow/utils/Parameters.py
@@ -355,7 +355,6 @@ class ParametersModelRANS2P(ParametersModelBase):
         coeffs.LS_model = LS_model
         coeffs.Closure_0_model = K_model
         coeffs.Closure_1_model = DISS_model
-        coeffs.turbulenceClosureModel = pparams.useRANS
         coeffs.porosityTypes = porosityTypes
         coeffs.dragAlphaTypes = dragAlphaTypes
         coeffs.dragBetaTypes = dragBetaTypes

--- a/proteus/TwoPhaseFlow/utils/Parameters.py
+++ b/proteus/TwoPhaseFlow/utils/Parameters.py
@@ -186,7 +186,7 @@ class ParametersModelBase(FreezableClass):
 
     def initializePhysics(self):
         self.p.domain = self._Problem.domain
-        self.p.nd = self._Problem.nd
+        self.p.nd = self._Problem.domain.nd
         self.p.movingDomain = self._Problem.movingDomain
         self.p.genMesh = self._Problem.Parameters.mesh.genMesh
         # initialize extra parameters


### PR DESCRIPTION
# Mandatory Checklist

Please ensure that the following criteria are met:

- [x] Title of pull request describes the changes/features
- [x] Request at least 2 reviewers
- [x] If new files are being added, the files are no larger than 100kB. Post the file sizes.
- [ ] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
- [ ] New features have appropriate documentation strings (readable by sphinx)
- [x] Contributor has read and agreed with CONTRIBUTING.md and has added themselves to CONTRIBUTORS.md 

As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

# Description
This PR aims to simplify the structure of TPF for developers and users. 

- The `OutputStepping` object is now defined/initialized at Problem instantiation.
- `SystemNumerics` and `SystemPhysics` objects are introduced to maintain problem-level attributes like gravity, density, CFL number, etc. 
- the dimension of the problem is defined solely from `domain.nd`, so it does not need to be defined at various locations
- the `ns_model` and `ls_model` way of setting model combinations is reimplemented following the `addModel` API to make setting up standard problems easier

The workflow should now consist of declaring a TPF object followed by interacting with the attributes or calling member functions of those attributes. Ex. marin problem (abridged)
```
### Define Domain ###
domain = Domain.PiecewiseLinearComplexDomain(vertices=vertices,
                                             vertexFlags=vertexFlags,
                                             facets=facets,
                                             facetFlags=facetFlags,
                                             regions = regions,
                                             regionFlags = regionFlags,
                                             holes=holes)
domain.MeshOptions.setParallelPartitioningType('node')
domain.boundaryTags = boundaryTags
domain.polyfile="meshMarin"
domain.writePoly("meshMarin")
domain.MeshOptions.he = he
domain.MeshOptions.triangleOptions="VApq1.25q12feena%e" % ((he**3)/6.0,)

### Generate Mesh ###
mesh = mt.generateMesh(domain)

### Create TwoPhaseFlow Problem ###
myTpFlowProblem = TpFlow.TwoPhaseFlowProblem()
myTpFlowProblem.domain = domain
myTpFlowProblem.mesh = mesh

### Modify OutputStepping ###
myTpFlowProblem.outputStepping.final_time =opts.final_time
myTpFlowProblem.outputStepping.dt_output =opts.dt_output
myTpFlowProblem.outputStepping.systemStepExact = True

### Modify System Parameters ###
myTpFlowProblem.SystemNumerics.cfl = opts.cfl
myTpFlowProblem.SystemPhysics.setDefaults()
myTpFlowProblem.SystemPhysics.useDefaultModels(flowModel=1,interfaceModel=1)

### Set Initial and Boundary Conditions ###
myTpFlowProblem.modelDict['pressure'].p.initialConditions['p']=zero()
myTpFlowProblem.modelDict['flow'].p.initialConditions['u']=zero()
myTpFlowProblem.modelDict['flow'].p.initialConditions['v']=zero()
myTpFlowProblem.modelDict['flow'].p.initialConditions['w']=zero()
myTpFlowProblem.modelDict['clsvof'].p.initialConditions['clsvof'] = clsvof_init_cond()
myTpFlowProblem.modelDict['pressureInc'].p.initialConditions['pInc'] = zero()
myTpFlowProblem.modelDict['pressureInit'].p.initialConditions['pInit'] = zero()

myTpFlowProblem.boundaryConditions = boundaryConditions

myTpFlowProblem.useBoundaryConditionsModule = False

### Set Model-level Physics/Numerics  ###
m = myTpFlowProblem.modelDict
m['clsvof'].p.coefficients.disc_ICs = disc_ICs
m['flow'].p.coefficients.useVF = 1.0
m['flow'].p.coefficients.eb_bc_penalty_constant = 1e6
m['flow'].p.coefficients.ARTIFICIAL_VISCOSITY = opts.ARTIFICIAL_VISCOSITY
```
