### PR TITLE
Fix to allow for hotstarting with systemStepExact=False

### DIFF
--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -870,6 +870,7 @@ class NS_base(object):  # (HasTraits):
                 #the number of nodes in an adapted mesh is not necessarily going to be the same as that of the solution field when archived...but it's not important because things should be bookkept correctly later on
                 #if not isinstance(p.domain,Domain.PUMIDomain):
 
+                m.stepController.t_model_last=time
                 for lm,lu,lr in zip(m.levelModelList,m.uList,m.rList):
                     for cj in range(lm.coefficients.nc):
 

--- a/proteus/tests/TwoPhaseFlow/damBreak.py
+++ b/proteus/tests/TwoPhaseFlow/damBreak.py
@@ -20,7 +20,8 @@ opts= Context.Options([
     ("dt_output",0.01,"Time interval to output solution"),
     ("cfl",0.25,"Desired CFL restriction"),
     ("he",0.01,"he relative to Length of domain in x"),
-    ("refinement",3,"level of refinement")
+    ("refinement",3,"level of refinement"),
+    ("hotstart",False,"will be hotstartting?"),
     ])
 
 # ****************** #
@@ -105,7 +106,12 @@ class clsvof_init_cond(object):
 # ***** Create myTwoPhaseFlowProblem ***** #
 ############################################
 outputStepping = TpFlow.OutputStepping(opts.final_time,dt_output=opts.dt_output)
-outputStepping.systemStepExact = True
+
+if opts.hotstart:
+    outputStepping.systemStepExact = False
+else:
+    outputStepping.systemStepExact = True
+
 initialConditions = {'pressure': zero(),
                      'pressure_increment': zero(),
                      'vel_u': zero(),

--- a/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
+++ b/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
@@ -63,9 +63,9 @@ class TestTwoPhaseFlow(object):
                   "damBreak.py -l5 -v -C 'final_time=0.1 dt_output=0.1 he=0.1'")
         self.compare_vs_saved_files("damBreak")
 
-    def test_damBreak_hotstart(self):
-        os.system("parun --TwoPhaseFlow --path " + self.path + " "
-                  "damBreak.py -l5 -v -H -C 'final_time=0.1 dt_output=0.1 he=0.1 hotstart=True'")
+    #def test_damBreak_hotstart(self):
+    #    os.system("parun --TwoPhaseFlow --path " + self.path + " "
+    #              "damBreak.py -l5 -v -H -C 'final_time=0.1 dt_output=0.1 he=0.1 hotstart=True'")
 
     @pytest.mark.skip(reason="numerics are very sensitive, hashdist build doesn't pass but conda does")
     def test_damBreak_solver_options(self):

--- a/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
+++ b/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
@@ -63,9 +63,9 @@ class TestTwoPhaseFlow(object):
                   "damBreak.py -l5 -v -C 'final_time=0.1 dt_output=0.1 he=0.1'")
         self.compare_vs_saved_files("damBreak")
 
-    #def test_damBreak_hotstart(self):
-    #    os.system("parun --TwoPhaseFlow --path " + self.path + " "
-    #              "damBreak.py -l5 -v -H -C 'final_time=0.1 dt_output=0.1 he=0.1 hotstart=True'")
+    def test_damBreak_hotstart(self):
+        os.system("parun --TwoPhaseFlow --path " + self.path + " "
+                  "damBreak.py -l5 -v -H -C 'final_time=0.1 dt_output=0.1 he=0.1 hotstart=True'")
 
     @pytest.mark.skip(reason="numerics are very sensitive, hashdist build doesn't pass but conda does")
     def test_damBreak_solver_options(self):

--- a/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
+++ b/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
@@ -63,6 +63,12 @@ class TestTwoPhaseFlow(object):
                   "damBreak.py -l5 -v -C 'final_time=0.1 dt_output=0.1 he=0.1'")
         self.compare_vs_saved_files("damBreak")
 
+    def test_damBreak_hotstart(self):
+        os.system("parun --TwoPhaseFlow --path " + self.path + " "
+                  "damBreak.py -l5 -v -H -C 'final_time=0.1 dt_output=0.1 he=0.1 hotstart=True'")
+        self.compare_vs_saved_files("damBreak_hotstart")
+
+
     @pytest.mark.skip(reason="numerics are very sensitive, hashdist build doesn't pass but conda does")
     def test_damBreak_solver_options(self):
         os.system("parun --TwoPhaseFlow --path " + self.path + " "

--- a/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
+++ b/proteus/tests/TwoPhaseFlow/test_TwoPhaseFlow.py
@@ -66,8 +66,6 @@ class TestTwoPhaseFlow(object):
     def test_damBreak_hotstart(self):
         os.system("parun --TwoPhaseFlow --path " + self.path + " "
                   "damBreak.py -l5 -v -H -C 'final_time=0.1 dt_output=0.1 he=0.1 hotstart=True'")
-        self.compare_vs_saved_files("damBreak_hotstart")
-
 
     @pytest.mark.skip(reason="numerics are very sensitive, hashdist build doesn't pass but conda does")
     def test_damBreak_solver_options(self):


### PR DESCRIPTION
# Mandatory Checklist

Please ensure that the following criteria are met:

- [ ] Title of pull request describes the changes/features
- [ ] Request at least 2 reviewers
- [ ] If new files are being added, the files are no larger than 100kB. Post the file sizes.
- [ ] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
- [ ] New features have appropriate documentation strings (readable by sphinx)
- [ ] Contributor has read and agreed with CONTRIBUTING.md and has added themselves to CONTRIBUTORS.md 

As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

# Description

Addresses #1235. Not setting the model time prior to proceeding with calculation leads to an infinite loop.

Thanks @cekees for the suggested fix.

Added a test within `tests/TwoPhaseFlow` to test for the fix. Note to keep in mind is that the test is to avoid changes to the infinite loop fix.

I tried setting a test to compare numerical results but I believe something along the lines of #1184 was causing a different behavior between the directory-level `pytest` call and a `make test` call at the root. 